### PR TITLE
Audio Playback Fixes

### DIFF
--- a/Wobble/Audio/Tracks/AudioTrack.cs
+++ b/Wobble/Audio/Tracks/AudioTrack.cs
@@ -276,7 +276,16 @@ namespace Wobble.Audio.Tracks
                 return;
             }
 
-            Time = (Position + (Time + timeSinceLastFrame * Rate)) / 2;
+            // Audio Position will stablize if BASS Audio Track Position is above the target value.
+            var target = Time + timeSinceLastFrame * Rate;
+            if (Position > target)
+            {
+                Time = (Position + target) / 2;
+                return;
+            }
+
+            // Use Delta Time if Audio position doesn't need to be stablized.
+            Time = target;
         }
 
         /// <inheritdoc />

--- a/Wobble/Audio/Tracks/AudioTrack.cs
+++ b/Wobble/Audio/Tracks/AudioTrack.cs
@@ -46,8 +46,8 @@ namespace Wobble.Audio.Tracks
         }
 
         /// <summary>
-        ///     The true position of the audio, taking into frame times. Use this for more accurate
-        ///     results (such as for rhythm games, or things where the audio time really matters)
+        ///     The true position of the audio in milliseconds, taking into frame times. Use this for more accurate
+        ///     results (such as for rhythm games, or things where the audio time really matters.)
         /// </summary>
         public double Time { get; private set; }
 

--- a/Wobble/WobbleGame.cs
+++ b/Wobble/WobbleGame.cs
@@ -45,7 +45,7 @@ namespace Wobble
         public SpriteBatch SpriteBatch { get; private set; }
 
         /// <summary>
-        ///     The amount of time elapsed since the previous frame.
+        ///     The amount of time elapsed since the previous frame in Milliseconds.
         /// </summary>
         public double TimeSinceLastFrame { get; private set; }
 


### PR DESCRIPTION
Audio Playback should be accurate after these fixes.
Documentation has also been updated so that we know that audio time is in milliseconds.