### PR TITLE
Linux support

### DIFF
--- a/Wobble.Tests/Wobble.Tests.csproj
+++ b/Wobble.Tests/Wobble.Tests.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JDG.Monogame.Content.Builder" Version="1.0.1" />
-    <PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Wobble/Platform/Linux/NativeLibrary.cs
+++ b/Wobble/Platform/Linux/NativeLibrary.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Wobble.Platform.Linux
+{
+    public class NativeLibrary
+    {
+        [DllImport("libdl.so.2", EntryPoint = "dlopen")]
+        private static extern IntPtr dlopen(string library, LoadFlags flags);
+
+        /// <summary>
+        /// Loads a library with flags to use with dlopen. Uses <see cref="LoadFlags"/> for the flags
+        ///
+        /// Uses NATIVE_DLL_SEARCH_DIRECTORIES and then ld.so for library paths
+        /// </summary>
+        /// <param name="library">Full name of the library</param>
+        /// <param name="flags">See 'man dlopen' for more information.</param>
+        public static void Load(string library, LoadFlags flags)
+        {
+            var paths = (string)AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES");
+            foreach (var path in paths.Split(':'))
+            {
+                if (dlopen(Path.Combine(path, library), flags) != IntPtr.Zero)
+                    break;
+            }
+        }
+
+        [Flags]
+        public enum LoadFlags
+        {
+            RTLD_LAZY = 0x00001,
+            RTLD_NOW = 0x00002,
+            RTLD_BINDING_MASK = 0x00003,
+            RTLD_NOLOAD = 0x00004,
+            RTLD_DEEPBIND = 0x00008,
+            RTLD_GLOBAL = 0x00100,
+            RTLD_LOCAL = 0x00000,
+            RTLD_NODELETE = 0x01000
+        }
+    }
+}

--- a/Wobble/WobbleGame.cs
+++ b/Wobble/WobbleGame.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
@@ -13,6 +14,7 @@ using Wobble.Input;
 using Wobble.IO;
 using Wobble.Logging;
 using Wobble.Platform;
+using Wobble.Platform.Linux;
 using Wobble.Screens;
 using Wobble.Window;
 
@@ -81,6 +83,12 @@ namespace Wobble
 
             GameBase.Game = this;
             GlobalUserInterface = new GlobalUserInterface();
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                // Required for libbass_fx.so to load properly on Linux and not crash (see https://github.com/ppy/osu/issues/2852).
+                NativeLibrary.Load("libbass.so", NativeLibrary.LoadFlags.RTLD_LAZY | NativeLibrary.LoadFlags.RTLD_GLOBAL);
+            }
         }
 
         /// <summary>

--- a/Wobble/WobbleGame.cs
+++ b/Wobble/WobbleGame.cs
@@ -26,14 +26,9 @@ namespace Wobble
     public abstract class WobbleGame : Game
     {
         /// <summary>
-        ///     The path of the current executable.
-        /// </summary>
-        public static string ExecutablePath => System.Reflection.Assembly.GetExecutingAssembly().CodeBase.Replace(@"file:///", "");
-
-        /// <summary>
         ///     The current working directory of the executable.
         /// </summary>
-        public static string WorkingDirectory => Path.GetDirectoryName(ExecutablePath).Replace(@"file:\", "");
+        public static string WorkingDirectory => AppDomain.CurrentDomain.BaseDirectory;
 
         /// <summary>
         /// </summary>


### PR DESCRIPTION
This PR makes Wobble.Tests run fine on Linux including audio.

- Removed dependencies on `MonoGame.Content.Builder` as per @Swan's suggestion because they seem to be Windows-specific.
- Changed the way `WorkingDirectory` is retrieved to a solution that works on both Windows and Linux. The previous solution required replacing `file:///`, which was necessary on Windows but cut the initial slash of an absolute path on Linux, thus turning it into a relative directory and breaking everything.
- Added code to manually load `libbass.so` on Linux to prevent `libbass_fx.so` crashing on load. This is the same as the fix for a similar issue in osu-framework.

Running on Linux uses the native `libbass.so` and `libbass_fx.so`, if you don't have that installed you need to set the `LD_LIBRARY_PATH` environment variable to the binary output folder. I believe that's the current state of things on the osu-framework side too.