### PR TITLE
Update Sprite Indexing

### DIFF
--- a/Wobble/Assets/AssetLoader.cs
+++ b/Wobble/Assets/AssetLoader.cs
@@ -77,8 +77,8 @@ namespace Wobble.Assets
             for (var i = 0; i < rows * columns; i++)
             {
                 // Get the specific row and column from the index.
-                var column = i / rows;
-                var row = i % rows;
+                var row = i / columns;
+                var column = i % columns;
 
                 var sourceRect = new Rectangle(imgWidth * column, imgHeight * row, imgWidth, imgHeight);
                 var cropTexture = new Texture2D(GameBase.Game.GraphicsDevice, sourceRect.Width, sourceRect.Height);


### PR DESCRIPTION
Sprite indexing should follow typical sprite-sheet convention.
Sprites should be indexed as so:
1    2    3    4
5    6    7    8
9    10    11    12

Rather than this:
1    4    7    10
2    5    8    11
3    6    9    12