### PR TITLE
Add C-w and C-u support to TextBox

### DIFF
--- a/Wobble/Graphics/UI/Form/Textbox.cs
+++ b/Wobble/Graphics/UI/Form/Textbox.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.Xna.Framework;
 using Wobble.Assets;
 using Wobble.Graphics.Sprites;
@@ -422,6 +423,31 @@ namespace Wobble.Graphics.UI.Form
 
                 if (!string.IsNullOrEmpty(clipboardText))
                     RawText += clipboardText;
+
+                ReadjustTextbox();
+                Selected = false;
+            }
+
+            // CTRL+W: kill word backwards.
+            // This means killing all trailing whitespace and then all trailing non-whitespace.
+            if (KeyboardManager.IsUniqueKeyPress(Keys.W))
+            {
+                var withoutTrailingWhitespace = RawText.TrimEnd();
+                var nonWhitespacesInTheEnd = withoutTrailingWhitespace.ToCharArray()
+                    .Select(c => c).Reverse().TakeWhile(c => !char.IsWhiteSpace(c)).Count();
+                RawText = withoutTrailingWhitespace.Substring(0,
+                    withoutTrailingWhitespace.Length - nonWhitespacesInTheEnd);
+
+                ReadjustTextbox();
+                Selected = false;
+            }
+
+            // Ctrl+U: kill line backwards.
+            // Delete from the cursor position to the start of the line.
+            if (KeyboardManager.IsUniqueKeyPress(Keys.U))
+            {
+                // Since we don't have a concept of a cursor, simply delete the whole text.
+                RawText = "";
 
                 ReadjustTextbox();
                 Selected = false;


### PR DESCRIPTION
This makes my life way easier.

1. `keys=4 somecoolmap`
2. Done playing, want something else but still with `keys=4`
3. Hit CTRL+W, now it's `keys=4 ` (with a space in the end), can enter another name straight away

CTRL-U is another commonly used thing, which clears the whole line in this case.

Both of them are standard readline shortcuts which work in just about any reasonable terminal program, so I'm very used to them.