### PR TITLE
Fix Linux text clipping and wrapping

### DIFF
--- a/Wobble/Graphics/BitmapFonts/BitmapFontFactory.cs
+++ b/Wobble/Graphics/BitmapFonts/BitmapFontFactory.cs
@@ -84,14 +84,16 @@ namespace Wobble.Graphics.BitmapFonts
 
             // Here we're creating a "virtual" graphics instance to measure
             // the size of the text.
-            using (var g = System.Drawing.Graphics.FromHwnd(IntPtr.Zero))
+            using (var bmp = new Bitmap(1, 1, PixelFormat.Format32bppArgb))
+            using (var g = System.Drawing.Graphics.FromImage(bmp))
             using (var format = new StringFormat())
             {
                 g.SmoothingMode = SmoothingMode.HighQuality;
                 g.InterpolationMode = InterpolationMode.HighQualityBilinear;
                 g.PixelOffsetMode = PixelOffsetMode.HighQuality;
-                g.TextRenderingHint = TextRenderingHint.SingleBitPerPixelGridFit;
+                g.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
                 g.CompositingQuality = CompositingQuality.HighQuality;
+                g.PageUnit = GraphicsUnit.Pixel;
 
                 format.Alignment = alignment;
                 format.LineAlignment = alignment;
@@ -101,7 +103,7 @@ namespace Wobble.Graphics.BitmapFonts
             }
 
             // Create the actual bitmap using the size of the text.
-            using (var bmp = new Bitmap((int) textSize.Width, (int) textSize.Height, PixelFormat.Format32bppArgb))
+            using (var bmp = new Bitmap((int) (textSize.Width + 0.5), (int) (textSize.Height + 0.5), PixelFormat.Format32bppArgb))
             using (var g = System.Drawing.Graphics.FromImage(bmp))
             using (var brush = new SolidBrush(System.Drawing.Color.White))
             using (var format = new StringFormat())
@@ -111,6 +113,7 @@ namespace Wobble.Graphics.BitmapFonts
                 g.PixelOffsetMode = PixelOffsetMode.HighQuality;
                 g.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
                 g.CompositingQuality = CompositingQuality.HighQuality;
+                g.PageUnit = GraphicsUnit.Pixel;
 
                 format.Alignment = alignment;
                 format.LineAlignment = alignment;


### PR DESCRIPTION
This fixes incorrect (too narrow) text size returned by MeasureString on Linux. I've no idea what exactly is the cause, but using a 1×1 bitmap instead of a zero HWND did the trick. I made the rest of the settings match up too just in case.

The font size is a little too high but all the clipping and wrapping bullshit is gone.

![image](https://user-images.githubusercontent.com/1794388/52083802-7f7f5080-25b1-11e9-83bd-4b130ca386a6.png)
![image](https://user-images.githubusercontent.com/1794388/52083834-9e7de280-25b1-11e9-9022-73a9225331df.png)
![image](https://user-images.githubusercontent.com/1794388/52083844-a63d8700-25b1-11e9-8785-cbcfe21e445d.png)
![image](https://user-images.githubusercontent.com/1794388/52083853-ae95c200-25b1-11e9-92ac-bf2b1afc20c8.png)
