### PR TITLE
Fix FPS counter alignment

### DIFF
--- a/Wobble/Graphics/UI/Debugging/FpsCounter.cs
+++ b/Wobble/Graphics/UI/Debugging/FpsCounter.cs
@@ -61,7 +61,8 @@ namespace Wobble.Graphics.UI.Debugging
             FrameRate = FrameCounter;
             FrameCounter = 0;
 
-            TextFps.Text = $"FPS: {FrameRate}";
+            TextFps.Text = $"{FrameRate} FPS";
+            Size = TextFps.Size;
             base.Update(gameTime);
         }
 


### PR DESCRIPTION
Makes the FPS counter properly aligned to the bottom right. Text changed to number FPS so that the stationary part is anchored to the aligned side.
![image](https://user-images.githubusercontent.com/1794388/52120197-9dd66200-262c-11e9-9cb1-38ec02348f9e.png)
![image](https://user-images.githubusercontent.com/1794388/52120216-ac247e00-262c-11e9-9b22-24c827d3896a.png)
