### PR TITLE
Fix not audio pitching

### DIFF
--- a/Wobble/Audio/Tracks/AudioTrack.cs
+++ b/Wobble/Audio/Tracks/AudioTrack.cs
@@ -299,6 +299,12 @@ namespace Wobble.Audio.Tracks
             Length = Bass.ChannelBytes2Seconds(Stream,Bass.ChannelGetLength(Stream)) * 1000;
             Frequency = Bass.ChannelGetInfo(Stream).Frequency;
             Stream = BassFx.TempoCreate(Stream, BassFlags.FxFreeSource);
+
+            // Settings from osu-framework. With default settings there's a huge offset on rates below 1.
+            // With these settings there's still an offset on rates below 1, but it's not as bad (just like HT in osu!).
+            Bass.ChannelSetAttribute(Stream, ChannelAttribute.TempoUseQuickAlgorithm, 1);
+            Bass.ChannelSetAttribute(Stream, ChannelAttribute.TempoOverlapMilliseconds, 4);
+            Bass.ChannelSetAttribute(Stream, ChannelAttribute.TempoSequenceMilliseconds, 30);
         }
 
         /// <summary>


### PR DESCRIPTION
- At rates below 1 with pitching off the reported audio time is slightly off (you hit early). This is the same as how HT works in osu! and, well, probably unavoidable (unless someone wants to go ping the bassfx dev about this). Adjusting tempo parameters might also help if someone's into that.
- Tempo adjustment takes about 0.3 seconds to apply, be it switching pitching on and off or adjusting rates. Not a terribly big deal.

Fixes #29 