### PR TITLE
AudioManager: log error from Bass.Init()

### DIFF
--- a/Wobble/Audio/AudioManager.cs
+++ b/Wobble/Audio/AudioManager.cs
@@ -25,7 +25,10 @@ namespace Wobble.Audio
         internal static void Initialize()
         {
             if (!Bass.Init())
-                throw new AudioEngineException("BASS has failed to initialize! Are your platform-specific dlls present?");
+            {
+                var error = Bass.LastError;
+                throw new AudioEngineException($"BASS has failed to initialize (error code: {(int) error}, name: \"{error}\")! Are your platform-specific dlls present?");
+            }
 
             Tracks = new List<AudioTrack>();
         }


### PR DESCRIPTION
Helps with diagnosing.