### PR TITLE
Fix some text rendering and input issues

### DIFF
--- a/Wobble/Graphics/BitmapFonts/BitmapFontFactory.cs
+++ b/Wobble/Graphics/BitmapFonts/BitmapFontFactory.cs
@@ -102,6 +102,10 @@ namespace Wobble.Graphics.BitmapFonts
                 textSize = g.MeasureString(text, font, maxWidth, format);
             }
 
+            // Bitmaps must have non-zero size.
+            textSize.Width = Math.Max(1, textSize.Width);
+            textSize.Height = Math.Max(1, textSize.Height);
+
             // Create the actual bitmap using the size of the text.
             using (var bmp = new Bitmap((int) (textSize.Width + 0.5), (int) (textSize.Height + 0.5), PixelFormat.Format32bppArgb))
             using (var g = System.Drawing.Graphics.FromImage(bmp))

--- a/Wobble/Graphics/UI/Form/Textbox.cs
+++ b/Wobble/Graphics/UI/Form/Textbox.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Xna.Framework;
@@ -318,7 +319,8 @@ namespace Wobble.Graphics.UI.Form
                         if (string.IsNullOrEmpty(RawText))
                             return;
 
-                        RawText = RawText.Remove(RawText.Length - 1);
+                        var charStartIndices = StringInfo.ParseCombiningCharacters(RawText);
+                        RawText = RawText.Remove(charStartIndices.Last());
 
                         if (RawText == "")
                         {

--- a/Wobble/Graphics/UI/Form/Textbox.cs
+++ b/Wobble/Graphics/UI/Form/Textbox.cs
@@ -465,12 +465,12 @@ namespace Wobble.Graphics.UI.Form
                     }
                     else
                     {
-                        var proposed = RawText += clipboardText;
+                        var proposed = RawText + clipboardText;
 
                         if (!AllowedCharacters.IsMatch(proposed))
                             return;
 
-                        RawText += clipboardText;
+                        RawText = proposed;
                     }
                 }
 


### PR DESCRIPTION
- Fixes a Linux crash when trying to render emoji;
- Fixes backspace deleting chars and not characters (chars are 16-bit and characters outside of the BMP consist of two chars, also characters like â can consist of two chars too);
- Fixes paste pasting twice;
- ~Changes `SDL_GetClipboardText()` to be interpreted as UTF-8, as by the docs.~