### PR TITLE
Improve text rendering at high resolutions

### DIFF
--- a/Wobble.Tests/Screens/Selection/SelectionScreenView.cs
+++ b/Wobble.Tests/Screens/Selection/SelectionScreenView.cs
@@ -81,7 +81,6 @@ namespace Wobble.Tests.Screens.Selection
                     Text =
                     {
                         Tint = Color.Black,
-                        ForceDrawAtSize = false
                     },
                     X = 5,
                     Y = i * 50 + i * 10 + 10,

--- a/Wobble.Tests/Screens/Tests/BitmapFont/TestBitmapFontScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/BitmapFont/TestBitmapFontScreenView.cs
@@ -38,7 +38,6 @@ namespace Wobble.Tests.Screens.Tests.BitmapFont
             {
                 Parent = Container,
                 Alignment = Alignment.MidRight,
-                ForceDrawAtSize = false
             };
         }
 

--- a/Wobble.Tests/Screens/Tests/Scrolling/TestScrollContainerScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/Scrolling/TestScrollContainerScreenView.cs
@@ -34,13 +34,13 @@ namespace Wobble.Tests.Screens.Tests.Scrolling
                 Tint = Color.Black
             });
 
-            ScrollContainer.AddContainedDrawable(new SpriteText("exo2-regular", "I love eggplants.", 12, true)
+            ScrollContainer.AddContainedDrawable(new SpriteText("exo2-regular", "I love eggplants.", 12)
             {
                 Alignment = Alignment.MidCenter,
                 Tint = Color.Purple
             });
 
-            var testText = new SpriteText("exo2-regular", "This should be clipped off-screen!", 12, true)
+            var testText = new SpriteText("exo2-regular", "This should be clipped off-screen!", 12)
             {
                 Alignment = Alignment.BotCenter,
                 Y = 0,

--- a/Wobble/Graphics/BitmapFonts/BitmapFontFactory.cs
+++ b/Wobble/Graphics/BitmapFonts/BitmapFontFactory.cs
@@ -73,7 +73,7 @@ namespace Wobble.Graphics.BitmapFonts
         /// <param name="textAlignment"></param>
         /// <param name="maxWidth"></param>
         ///  <returns></returns>
-        internal static Texture2D Create(string fontName, string text, int fontSize, Color color, Alignment textAlignment, int maxWidth)
+        internal static Texture2D Create(string fontName, string text, float fontSize, Color color, Alignment textAlignment, int maxWidth)
         {
             // Stores the size of the text & Texture2D
             SizeF textSize;
@@ -142,7 +142,7 @@ namespace Wobble.Graphics.BitmapFonts
         /// <param name="name"></param>
         /// <param name="size"></param>
         /// <returns></returns>
-        private static Font GetCustomFont(string name, int size)
+        private static Font GetCustomFont(string name, float size)
         {
             if (!CustomFonts.ContainsKey(name))
                 return null;

--- a/Wobble/Graphics/Sprites/SpriteText.cs
+++ b/Wobble/Graphics/Sprites/SpriteText.cs
@@ -83,21 +83,6 @@ namespace Wobble.Graphics.Sprites
         }
 
         /// <summary>
-        ///     If set to true, it will draw at the font size given instead of drawing higher and
-        ///     scaling down.
-        /// </summary>
-        private bool _forceDrawAtSize;
-        public bool ForceDrawAtSize
-        {
-            get => _forceDrawAtSize;
-            set
-            {
-                _forceDrawAtSize = value;
-                LoadTexture();
-            }
-        }
-
-        /// <summary>
         ///     The amount of text updates that have occurred in the previous second.
         /// </summary>
         private int AmountOfTextUpdatesInSecond { get; set; }
@@ -113,10 +98,9 @@ namespace Wobble.Graphics.Sprites
         /// <param name="font"></param>
         /// <param name="text"></param>
         /// <param name="fontSize"></param>
-        /// <param name="forceDrawAtSize"></param>
         /// <param name="maxWidth">The maximum width before it wraps to the next line</param>
         /// <exception cref="T:System.ArgumentException"></exception>
-        public SpriteText(string font, string text, int fontSize, bool forceDrawAtSize = true, int maxWidth = int.MaxValue)
+        public SpriteText(string font, string text, int fontSize, int maxWidth = int.MaxValue)
         {
             if (string.IsNullOrEmpty(font))
                 throw new ArgumentException("Font must be not null or empty.");
@@ -125,7 +109,6 @@ namespace Wobble.Graphics.Sprites
             _text = text;
             _fontSize = fontSize;
             _maxWidth = maxWidth;
-            _forceDrawAtSize = forceDrawAtSize;
 
             LoadTexture();
         }
@@ -154,10 +137,8 @@ namespace Wobble.Graphics.Sprites
                 return;
             }
 
-            Image = BitmapFontFactory.Create(Font, Text, ForceDrawAtSize ? FontSize : (int) (FontSize * 1.5f), Color.White, TextAlignment, MaxWidth);
-
-            var ratio = ForceDrawAtSize ? 1f : (float) FontSize / (FontSize * 1.5f);
-            Size = new ScalableVector2(Image.Width * ratio, Image.Height * ratio);
+            Image = BitmapFontFactory.Create(Font, Text, FontSize, Color.White, TextAlignment, MaxWidth);
+            Size = new ScalableVector2(Image.Width, Image.Height);
 
             AmountOfTextUpdatesInSecond++;
 

--- a/Wobble/Graphics/Sprites/SpriteText.cs
+++ b/Wobble/Graphics/Sprites/SpriteText.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Wobble.Assets;
 using Wobble.Graphics.BitmapFonts;
 using Wobble.Logging;
+using Wobble.Window;
 
 namespace Wobble.Graphics.Sprites
 {
@@ -137,8 +138,14 @@ namespace Wobble.Graphics.Sprites
                 return;
             }
 
-            Image = BitmapFontFactory.Create(Font, Text, FontSize, Color.White, TextAlignment, MaxWidth);
-            Size = new ScalableVector2(Image.Width, Image.Height);
+            var scale = WindowManager.ScreenScale.X;
+
+            // Some stuff (namely DrawableLog and the FPS counter) wants to draw text before anything is initialized.
+            if (scale == 0)
+                scale = 1;
+
+            Image = BitmapFontFactory.Create(Font, Text, FontSize * scale, Color.White, TextAlignment, (int) (MaxWidth * scale));
+            Size = new ScalableVector2(Image.Width / scale, Image.Height / scale);
 
             AmountOfTextUpdatesInSecond++;
 

--- a/Wobble/Graphics/UI/Form/Textbox.cs
+++ b/Wobble/Graphics/UI/Form/Textbox.cs
@@ -150,7 +150,7 @@ namespace Wobble.Graphics.UI.Form
             PlaceholderText = placeHolderText;
             _rawText = initialText;
 
-            InputText = new SpriteText(font, RawText, fontSize, false)
+            InputText = new SpriteText(font, RawText, fontSize)
             {
                 TextAlignment = Alignment.TopLeft,
                 X = 5,

--- a/Wobble/Logging/DrawableLog.cs
+++ b/Wobble/Logging/DrawableLog.cs
@@ -37,7 +37,7 @@ namespace Wobble.Logging
         /// <param name="level"></param>
         public DrawableLog(string t, LogLevel level)
         {
-            Text = new SpriteText("Calibri", t, 16, true, (int) (WindowManager.Width / 0.75f))
+            Text = new SpriteText("Calibri", t, 16, (int) (WindowManager.Width / 0.75f))
             {
                 Parent = this,
                 Alignment = Alignment.MidLeft,


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1794388/53570504-bd06d780-3b77-11e9-885a-f64325a34198.png)

After:

![image](https://user-images.githubusercontent.com/1794388/53570519-c3954f00-3b77-11e9-867e-624809a791fb.png)

If you have a 320×240 screen and can't see:
![image](https://user-images.githubusercontent.com/1794388/53570569-e1fb4a80-3b77-11e9-86a8-3f9366563afb.png)
![image](https://user-images.githubusercontent.com/1794388/53570586-eaec1c00-3b77-11e9-8bdd-3ecce387043e.png)

I blame libgdiplus for the black border.