### PR TITLE
Improve Linux text

### DIFF
--- a/Wobble.Tests/Screens/Selection/SelectionScreen.cs
+++ b/Wobble.Tests/Screens/Selection/SelectionScreen.cs
@@ -30,6 +30,7 @@ namespace Wobble.Tests.Screens.Selection
             {ScreenType.Primitives, "Primitives"},
             {ScreenType.ImGui, "Imgui"},
             {ScreenType.Scaling, "Scaling"},
+            {ScreenType.TextSizes, "Text Sizes"},
         };
 
         public SelectionScreen() => View = new SelectionScreenView(this);
@@ -55,5 +56,6 @@ namespace Wobble.Tests.Screens.Selection
         Primitives,
         ImGui,
         Scaling,
+        TextSizes,
     }
 }

--- a/Wobble.Tests/Screens/Selection/SelectionScreenView.cs
+++ b/Wobble.Tests/Screens/Selection/SelectionScreenView.cs
@@ -23,6 +23,7 @@ using Wobble.Tests.Screens.Tests.Scaling;
 using Wobble.Tests.Screens.Tests.Scrolling;
 using Wobble.Tests.Screens.Tests.SpriteMasking;
 using Wobble.Tests.Screens.Tests.TextInput;
+using Wobble.Tests.Screens.Tests.TextSizes;
 using Wobble.Window;
 
 namespace Wobble.Tests.Screens.Selection
@@ -135,6 +136,9 @@ namespace Wobble.Tests.Screens.Selection
                         break;
                     case ScreenType.Scaling:
                         button.Clicked += (o, e) => ScreenManager.ChangeScreen(new TestScalingScreen());
+                        break;
+                    case ScreenType.TextSizes:
+                        button.Clicked += (o, e) => ScreenManager.ChangeScreen(new TestTextSizesScreen());
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/Wobble.Tests/Screens/Tests/TextSizes/TestSizesScreen.cs
+++ b/Wobble.Tests/Screens/Tests/TextSizes/TestSizesScreen.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Wobble.Screens;
+
+namespace Wobble.Tests.Screens.Tests.TextSizes
+{
+    public class TestTextSizesScreen : Screen
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public sealed override ScreenView View { get; protected set; }
+
+        public TestTextSizesScreen() => View = new TestTextSizesScreenView(this);
+    }
+}

--- a/Wobble.Tests/Screens/Tests/TextSizes/TestSizesScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/TextSizes/TestSizesScreenView.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Wobble.Graphics;
+using Wobble.Graphics.Primitives;
+using Wobble.Graphics.Sprites;
+using Wobble.Screens;
+
+namespace Wobble.Tests.Screens.Tests.TextSizes
+{
+    public class TestTextSizesScreenView : ScreenView
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="screen"></param>
+        public TestTextSizesScreenView(Screen screen) : base(screen)
+        {
+            new Sprite
+            {
+                Parent = Container,
+                Tint = Color.SkyBlue,
+                Width = Container.Width,
+                Height = Container.Height,
+            };
+
+            float y = 0;
+            for (int i = 1; i < 30; i++)
+            {
+                var line = new SpriteText("exo2-regular", "The quick brown fox jumps over the lazy dog", i)
+                {
+                    Parent = Container,
+                    Y = y,
+                };
+                y += line.Height;
+            }
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime) => Container?.Update(gameTime);
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime)
+        {
+            GameBase.Game.GraphicsDevice.Clear(Color.Black);
+            Container?.Draw(gameTime);
+
+            GameBase.Game.SpriteBatch.End();
+        }
+
+        public override void Destroy() => Container?.Destroy();
+    }
+}

--- a/Wobble/Graphics/BitmapFonts/BitmapFontFactory.cs
+++ b/Wobble/Graphics/BitmapFonts/BitmapFontFactory.cs
@@ -131,6 +131,11 @@ namespace Wobble.Graphics.BitmapFonts
                 // Dispose of the font.
                 font.Dispose();
 
+                // On Windows the alpha is not premultiplied. This results in subtle border artifacts when scaled or
+                // moved around improperly.
+                // On Linux the alpha is premultipled.
+                // This is regardless of the Bitmap PixelFormat.
+
                // bmp.RawFormat = ImageFormat.Png;
                 return AssetLoader.LoadTexture2D(ImageToByte2(bmp));
             }

--- a/Wobble/Graphics/Sprites/Sprite.cs
+++ b/Wobble/Graphics/Sprites/Sprite.cs
@@ -197,6 +197,7 @@ namespace Wobble.Graphics.Sprites
                 return;
 
             // Update the render rectangle
+            // Add Width / 2 and Height / 2 to X, Y because that's what Origin is set to (in the Image setter).
             RenderRectangle = new RectangleF(ScreenRectangle.X + ScreenRectangle.Width / 2f, ScreenRectangle.Y + ScreenRectangle.Height / 2f,
                 ScreenRectangle.Width, ScreenRectangle.Height);
         }


### PR DESCRIPTION
Test on Windows to make sure I didn't break anything in process of picking the commit changes.

This is a low effort band-aid for Linux, there's the same black outline issue on Windows (although less pronounced), but fixing that would require considerably more effort.

### Before
![image](https://user-images.githubusercontent.com/1794388/56457450-d9f3a600-6383-11e9-8196-5a7a60c15177.png)

### After
![image](https://user-images.githubusercontent.com/1794388/56457453-dcee9680-6383-11e9-819c-40747b05e4dc.png)

### Before
![image](https://user-images.githubusercontent.com/1794388/56457457-f394ed80-6383-11e9-9bc9-f1f2420988d6.png)

### After
![image](https://user-images.githubusercontent.com/1794388/56457460-f98ace80-6383-11e9-9230-bb11094bb247.png)