### PR TITLE
Hot Reloading

### DIFF
--- a/Wobble.Extended/HotReload/HotLoader.cs
+++ b/Wobble.Extended/HotReload/HotLoader.cs
@@ -82,7 +82,7 @@ namespace Wobble.Extended.HotReload
         /// </summary>
         public void LoadDll()
         {
-            var path = $@"../../../../{ProjectName}/bin/debug/netcoreapp2.1/{ProjectName}.dll";
+            var path = $@"../../../../{ProjectName}/bin/Debug/netcoreapp2.1/{ProjectName}.dll";
 
             Asm = Assembly.Load(File.ReadAllBytes(path));
 

--- a/Wobble.Extended/HotReload/HotLoader.cs
+++ b/Wobble.Extended/HotReload/HotLoader.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended;
+
+namespace Wobble.Extended.HotReload
+{
+    public class HotLoader : IDisposable, IUpdate
+    {
+        /// <summary>
+        ///     The directory that will be watched for changes
+        /// </summary>
+        protected string ProjectDirectory { get; }
+
+        /// <summary>
+        ///     Watches the directory for changes
+        /// </summary>
+        public FileSystemWatcher Watcher { get; }
+
+        /// <summary>
+        ///     The compiling process
+        /// </summary>
+        protected ProcessStartInfo Compiler { get; set; }
+
+        /// <summary>
+        ///     The currently loaded assembly
+        /// </summary>
+        public Assembly Asm { get; private set; }
+
+        /// <summary>
+        ///     Fetches the name of the project from the directory
+        /// </summary>
+        protected string ProjectName => new DirectoryInfo(ProjectDirectory).Name;
+
+        /// <summary>
+        ///     The subscreen/test screen that will be drawn
+        /// </summary>
+        public dynamic Screen { get; set; }
+
+        /// <summary>
+        ///     If the previous compilation has failed
+        /// </summary>
+        public bool CompilationFailed { get; private set; }
+
+        /// <summary>
+        ///     If the hotloader is currently compiling
+        /// </summary>
+        public bool IsCompiling => Compiler != null;
+
+        /// <summary>
+        ///     Action to be called after recompiling
+        /// </summary>
+        public Action AfterCompiling { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="projectDirectory"></param>
+        /// <param name="afterCompiling"></param>
+        /// <param name="filter"></param>
+        public HotLoader(string projectDirectory, Action afterCompiling = null, string filter = "*.cs")
+        {
+            ProjectDirectory = projectDirectory;
+            AfterCompiling = afterCompiling;
+
+            Watcher = new FileSystemWatcher
+            {
+                Path = ProjectDirectory,
+                NotifyFilter = NotifyFilters.Size,
+                Filter = filter,
+                EnableRaisingEvents = true,
+                IncludeSubdirectories = true
+            };
+
+            Watcher.Changed += OnChanged;
+        }
+
+        /// <summary>
+        ///     Loads in the new dll
+        /// </summary>
+        public void LoadDll()
+        {
+            var path = $@"../../../../{ProjectName}/bin/debug/netcoreapp2.1/{ProjectName}.dll";
+
+            Asm = Assembly.Load(File.ReadAllBytes(path));
+
+            foreach (var type in Asm.GetExportedTypes())
+            {
+                if (Screen == null)
+                    break;
+
+                if (type.FullName == Screen.GetType().ToString())
+                {
+                    // We found our gamelogic type, set our dynamic types logic, and state
+                    var oldScreen = Screen;
+
+                    Screen = Activator.CreateInstance(type);
+                    oldScreen?.Destroy();
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Recompiles the project when changes are made to filtered files.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected void OnChanged(object sender, FileSystemEventArgs e)
+        {
+            CompileProject();
+            AfterCompiling?.Invoke();
+            LoadDll();
+        }
+
+        /// <summary>
+        ///     Recompiles the project
+        /// </summary>
+        /// <returns></returns>
+        public void CompileProject()
+        {
+            Watcher.EnableRaisingEvents = false;
+
+            Console.WriteLine($"Initializing Compiliation for project: {ProjectName}");
+
+            if (Compiler != null)
+            {
+                Watcher.EnableRaisingEvents = true;
+                return;
+            }
+
+            const string command = "dotnet";
+            var args = $"build {ProjectDirectory}/{new DirectoryInfo(ProjectDirectory).Name}.csproj";
+
+            Compiler = new ProcessStartInfo(command, args)
+            {
+                WorkingDirectory = Environment.CurrentDirectory,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WindowStyle = ProcessWindowStyle.Hidden
+            };
+
+            var p = Process.Start(Compiler);
+
+            if (p == null)
+            {
+                Compiler = null;
+                LoadDll();
+                Watcher.EnableRaisingEvents = true;
+                return;
+            }
+
+            var output = p.StandardOutput.ReadToEnd();
+            output += p.StandardError.ReadToEnd();
+
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+            {
+                Compiler = null;
+                Console.WriteLine("Compilation Success!");
+                CompilationFailed = false;
+                Watcher.EnableRaisingEvents = true;
+
+                AfterCompiling?.Invoke();
+                return;
+            }
+
+            CompilationFailed = true;
+            Compiler = null;
+            Watcher.EnableRaisingEvents = true;
+            Console.WriteLine(output);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public void Update(GameTime gameTime) => Screen?.Update(gameTime);
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public void Draw(GameTime gameTime) => Screen?.Draw(gameTime);
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Dispose() => Watcher.Dispose();
+    }
+}

--- a/Wobble.Extended/HotReload/HotLoaderGame.cs
+++ b/Wobble.Extended/HotReload/HotLoaderGame.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Wobble.Assets;
+using Wobble.Extended.HotReload.Screens;
+using Wobble.Screens;
+
+namespace Wobble.Extended.HotReload
+{
+    public abstract class HotLoaderGame : WobbleGame
+    {
+        protected override bool IsReadyToUpdate { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public HotLoader HotLoader { get; }
+
+        /// <summary>
+        /// </summary>
+        public HotLoaderScreen HotLoaderScreen { get; protected set; }
+
+        public HotLoaderGame(HotLoader hl)
+        {
+            HotLoader = hl;
+            IsMouseVisible = true;
+        }
+
+        protected override void Initialize()
+        {
+            HotLoaderScreen = InitializeHotLoaderScreen();
+            base.Initialize();
+        }
+
+        protected override void LoadContent()
+        {
+            base.LoadContent();
+
+            ScreenManager.ChangeScreen(HotLoaderScreen);
+
+            HotLoader.CompileProject();
+            HotLoader.LoadDll();
+
+            IsReadyToUpdate = true;
+        }
+
+        protected override void UnloadContent()
+        {
+            base.UnloadContent();
+        }
+
+        protected override void Update(GameTime gameTime)
+        {
+            base.Update(gameTime);
+        }
+
+        protected override void Draw(GameTime gameTime)
+        {
+            base.Draw(gameTime);
+        }
+
+        protected abstract HotLoaderScreen InitializeHotLoaderScreen();
+    }
+}

--- a/Wobble.Extended/HotReload/Screens/HotLoaderScreen.cs
+++ b/Wobble.Extended/HotReload/Screens/HotLoaderScreen.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using Wobble.Screens;
+
+namespace Wobble.Extended.HotReload.Screens
+{
+    public class HotLoaderScreen : Screen
+    {
+        public sealed override ScreenView View { get; protected set; }
+
+        public HotLoaderScreen(Dictionary<string, Type> testScreens) => View = new HotLoaderScreenView(this, testScreens);
+    }
+}

--- a/Wobble.Extended/HotReload/Screens/HotLoaderScreenView.cs
+++ b/Wobble.Extended/HotReload/Screens/HotLoaderScreenView.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Wobble.Extended.HotReload.Screens.UI;
+using Wobble.Graphics;
+using Wobble.Graphics.Animations;
+using Wobble.Input;
+using Wobble.Screens;
+
+namespace Wobble.Extended.HotReload.Screens
+{
+    public class HotLoaderScreenView : ScreenView
+    {
+        /// <summary>
+        ///     The screens that are ready to be hotloaded
+        /// </summary>
+        private Dictionary<string, Type> TestScreens { get; }
+
+        /// <summary>
+        /// </summary>
+        private CompilingNotification CompilingNotification { get; }
+
+        /// <summary>
+        /// </summary>
+        public HotLoader HotLoader { get; }
+
+        /// <summary>
+        /// </summary>
+        private HotLoadingBrowser Browser { get; }
+
+        /// <summary>
+        /// </summary>
+        private bool BrowserActive { get; set; } = true;
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="screen"></param>
+        /// <param name="testScreens"></param>
+        public HotLoaderScreenView(Screen screen, Dictionary<string, Type> testScreens) : base(screen)
+        {
+            TestScreens = testScreens;
+
+            CompilingNotification = new CompilingNotification()
+            {
+                Parent = Container,
+                Alignment = Alignment.MidCenter
+            };
+
+            Browser = new HotLoadingBrowser(this, testScreens) {Parent = Container};
+
+            var game = (HotLoaderGame) GameBase.Game;
+            HotLoader = game.HotLoader;
+
+            Console.WriteLine("Press the Tilde (~) key to open/close the test browser");
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            if (KeyboardManager.IsUniqueKeyPress(Keys.OemTilde))
+            {
+                BrowserActive = !BrowserActive;
+                Browser?.ClearAnimations();
+                Browser?.MoveToX(BrowserActive ? 0 : -Browser.Width - 10, Easing.OutQuint, 400);
+            }
+
+            HandleCompilingNotificationAnimations(gameTime);
+
+            if (!HotLoader.IsCompiling && !HotLoader.CompilationFailed)
+                HotLoader?.Update(gameTime);
+
+            Container?.Update(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime)
+        {
+            GameBase.Game.GraphicsDevice.Clear(Color.CornflowerBlue);
+
+            HotLoader?.Draw(gameTime);
+            Container?.Draw(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy() => Container?.Destroy();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void HandleCompilingNotificationAnimations(GameTime gameTime)
+        {
+            var targetAlpha = HotLoader.IsCompiling || HotLoader.CompilationFailed ? 1 : 0;
+
+            CompilingNotification.Alpha = MathHelper.Lerp(CompilingNotification.Alpha, targetAlpha,
+                (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / 60, 1));
+
+            if (!HotLoader.IsCompiling && HotLoader.CompilationFailed && CompilingNotification.Text.Text.Contains("re-compiled"))
+                CompilingNotification.SetCompilationFailedText();
+            else if (HotLoader.IsCompiling && CompilingNotification.Text.Text.Contains("Failed"))
+                CompilingNotification.SetCompilingText();
+        }
+
+        /// <summary>
+        ///     Changes to a new screen in the browser
+        /// </summary>
+        /// <param name="t"></param>
+        public void ChangeScreen(Type t)
+        {
+            foreach (Type type in HotLoader.Asm.GetExportedTypes())
+            {
+                if (type.FullName == t.FullName)
+                {
+                    // We found our gamelogic type, set our dynamic types logic, and state
+                    var oldScreen = HotLoader.Screen;
+
+                    HotLoader.Screen = Activator.CreateInstance(t);
+                    oldScreen?.Destroy();
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Wobble.Extended/HotReload/Screens/UI/CompilingNotification.cs
+++ b/Wobble.Extended/HotReload/Screens/UI/CompilingNotification.cs
@@ -1,0 +1,49 @@
+using Microsoft.Xna.Framework;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+using Wobble.Window;
+
+namespace Wobble.Extended.HotReload.Screens.UI
+{
+    public class CompilingNotification : Sprite
+    {
+        /// <summary>
+        /// </summary>
+        public SpriteText Text { get; }
+
+        /// <summary>
+        /// </summary>
+        public bool CompilationFailed { get; private set; }
+
+        /// <summary>
+        /// </summary>
+        public CompilingNotification()
+        {
+            Tint = new Color(24, 24, 24);
+            Size = new ScalableVector2(WindowManager.Width, 75);
+            SetChildrenAlpha = true;
+
+            Text = new SpriteText("Arial", "", 14)
+            {
+                Parent = this,
+                Alignment = Alignment.MidCenter
+            };
+
+            SetCompilingText();
+        }
+
+        public void SetCompilingText()
+        {
+            Text.Text = $"Please wait while the project gets re-compiled...";
+            Text.Tint = Color.White;
+            CompilationFailed = false;
+        }
+
+        public void SetCompilationFailedText()
+        {
+            Text.Text = "Failed to compile project. Please see the logs!";
+            Text.Tint = Color.Red;
+            CompilationFailed = true;
+        }
+    }
+}

--- a/Wobble.Extended/HotReload/Screens/UI/HotLoadingBrowser.cs
+++ b/Wobble.Extended/HotReload/Screens/UI/HotLoadingBrowser.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Wobble.Assets;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.UI.Buttons;
+using Wobble.Screens;
+using Wobble.Window;
+
+namespace Wobble.Extended.HotReload.Screens.UI
+{
+    public class HotLoadingBrowser : ScrollContainer
+    {
+        private Dictionary<string, Type> Screens { get; }
+
+        /// <summary>
+        /// </summary>
+        private List<ImageButton> Buttons { get; } = new List<ImageButton>();
+
+        /// <summary>
+        /// </summary>
+        private HotLoaderScreenView ScreenView { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="screen"></param>
+        /// <param name="screenview"></param>
+        /// <param name="screens"></param>
+        public HotLoadingBrowser(HotLoaderScreenView screenview, Dictionary<string, Type> screens)
+            : base(new ScalableVector2(250, WindowManager.Height), new ScalableVector2(250, WindowManager.Height))
+        {
+            ScreenView = screenview;
+            Screens = screens;
+            Tint = Color.Black;
+            Alpha = 0.85f;
+            CreateButtons();
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateButtons()
+        {
+            foreach (var test in Screens)
+                AddButton(test.Key);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="name"></param>
+        private void AddButton(string name)
+        {
+            var btn = new ImageButton(WobbleAssets.WhiteBox)
+            {
+                Size = new ScalableVector2(Width - 10, 30),
+                Alignment = Alignment.TopCenter,
+                Tint = new Color(60, 60, 60),
+                Y = Buttons.Count * 30 + 10 * (Buttons.Count)
+            };
+
+            btn.Clicked += (o, e) =>
+            {
+                ScreenView.ChangeScreen(Screens[name]);
+                Console.WriteLine($"Going to screen: {name}");
+            };
+
+            // ReSharper disable once ObjectCreationAsStatement
+            new SpriteText("Arial", name, 14)
+            {
+                Parent = btn,
+                UsePreviousSpriteBatchOptions = true,
+                Alignment = Alignment.MidCenter,
+            };
+
+            Buttons.Add(btn);
+
+            var totalHeight =  Buttons.Count * 30 + 10 * (Buttons.Count - 1);
+
+            if (totalHeight > Height)
+                ContentContainer.Height = totalHeight;
+            else
+                ContentContainer.Height = Height;
+
+            AddContainedDrawable(btn);
+        }
+    }
+}

--- a/Wobble.Extended/Wobble.Extended.csproj
+++ b/Wobble.Extended/Wobble.Extended.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\MonoGame\MonoGame.Framework\MonoGame.Framework.DesktopGL.Core.csproj" />
+      <ProjectReference Include="..\Wobble\Wobble.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Wobble.Tests.Assets/Textures.cs
+++ b/Wobble.Tests.Assets/Textures.cs
@@ -1,9 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Drawing.Imaging;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Xna.Framework.Graphics;
 using Wobble.Assets;
 

--- a/Wobble.Tests.Assets/Wobble.Tests.Assets.csproj
+++ b/Wobble.Tests.Assets/Wobble.Tests.Assets.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <RootNamespace>Wobble.Tests.Assets</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\MonoGame\MonoGame.Framework\MonoGame.Framework.DesktopGL.Core.csproj" />
+      <ProjectReference Include="..\Wobble\Wobble.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Wobble.Tests.Hotload/Program.cs
+++ b/Wobble.Tests.Hotload/Program.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using Wobble.Extended.HotReload;
+
+namespace Wobble.Tests.Hotload
+{
+    internal static class Program
+    {
+        /// <summary>
+        ///     The current working directory of the executable.
+        /// </summary>
+        public static string WorkingDirectory => WobbleGame.WorkingDirectory;
+
+        [STAThread]
+        internal static void Main(string[] args)
+        {
+            // Change the working directory to where the executable is.
+            Directory.SetCurrentDirectory(WorkingDirectory);
+            Environment.CurrentDirectory = WorkingDirectory;
+            
+            using (var game = new WobbleTestsGameHotload(new HotLoader("../../../../Wobble.Tests/")))
+                game.Run();
+        }
+    }
+}

--- a/Wobble.Tests.Hotload/Wobble.Tests.Hotload.csproj
+++ b/Wobble.Tests.Hotload/Wobble.Tests.Hotload.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Wobble.Extended\Wobble.Extended.csproj" />
+      <ProjectReference Include="..\Wobble.Tests.Assets\Wobble.Tests.Assets.csproj" />
+      <ProjectReference Include="..\Wobble.Tests\Wobble.Tests.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Wobble.Tests.Hotload/WobbleTestsGameHotload.cs
+++ b/Wobble.Tests.Hotload/WobbleTestsGameHotload.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Wobble.Extended.HotReload;
+using Wobble.Extended.HotReload.Screens;
+using Wobble.IO;
+using Wobble.Tests.Assets;
+using Wobble.Tests.Screens.Tests.Audio;
+using Wobble.Tests.Screens.Tests.Background;
+using Wobble.Tests.Screens.Tests.BitmapFont;
+using Wobble.Tests.Screens.Tests.BlurredBgImage;
+using Wobble.Tests.Screens.Tests.Discord;
+using Wobble.Tests.Screens.Tests.DrawingSprites;
+using Wobble.Tests.Screens.Tests.EasingAnimations;
+using Wobble.Tests.Screens.Tests.Imgui;
+using Wobble.Tests.Screens.Tests.Primitives;
+using Wobble.Tests.Screens.Tests.Scaling;
+using Wobble.Tests.Screens.Tests.Scrolling;
+using Wobble.Tests.Screens.Tests.SpriteMasking;
+using Wobble.Tests.Screens.Tests.TextSizes;
+using Wobble.Window;
+
+namespace Wobble.Tests.Hotload
+{
+    public class WobbleTestsGameHotload : HotLoaderGame
+    {
+        public WobbleTestsGameHotload(HotLoader hl) : base(hl)
+        {
+            WindowManager.ChangeScreenResolution(new Point(1366, 768));
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+        }
+
+        protected override void LoadContent()
+        {
+            base.LoadContent();
+
+            Resources.AddStore(new DllResourceStore("Wobble.Tests.Resources.dll"));
+            Textures.Load();
+            IsReadyToUpdate = true;
+        }
+
+        protected override void UnloadContent()
+        {
+            base.UnloadContent();
+        }
+
+        protected override void Update(GameTime gameTime)
+        {
+            base.Update(gameTime);
+        }
+
+        protected override void Draw(GameTime gameTime)
+        {
+            base.Draw(gameTime);
+        }
+
+        protected override HotLoaderScreen InitializeHotLoaderScreen() => new HotLoaderScreen(new Dictionary<string, Type>()
+        {
+            {"Drawing Sprites", typeof(TestDrawingSpritesScreen)},
+            {"Easing", typeof(TestEasingAnimationsScreen)},
+            {"ImGUI", typeof(TestImGuiScreen)},
+            {"Audio", typeof(TestAudioScreen)},
+            {"Background", typeof(TestBackgroundImageScreen)},
+            {"BitmapFont", typeof(TestBitmapFontScreen)},
+            {"Blurred BG Image", typeof(TestBlurredBackgroundImageScreen)},
+            {"Discord", typeof(TestDiscordScreen)},
+            {"Primitives", typeof(TestPrimitivesScreen)},
+            {"Scaling", typeof(TestScalingScreen)},
+            {"Scrolling", typeof(TestScrollContainerScreen)},
+            {"Sprite Masking", typeof(TestSpriteMaskingScreen)},
+            {"TextSizes", typeof(TestTextSizesScreen)}
+        });
+    }
+}

--- a/Wobble.Tests/Screens/Selection/SelectionScreen.cs
+++ b/Wobble.Tests/Screens/Selection/SelectionScreen.cs
@@ -30,7 +30,7 @@ namespace Wobble.Tests.Screens.Selection
             {ScreenType.Primitives, "Primitives"},
             {ScreenType.ImGui, "Imgui"},
             {ScreenType.Scaling, "Scaling"},
-            {ScreenType.TextSizes, "Text Sizes"},
+            {ScreenType.TextSizes, "memes"},
         };
 
         public SelectionScreen() => View = new SelectionScreenView(this);

--- a/Wobble.Tests/Screens/Selection/SelectionScreen.cs
+++ b/Wobble.Tests/Screens/Selection/SelectionScreen.cs
@@ -30,7 +30,7 @@ namespace Wobble.Tests.Screens.Selection
             {ScreenType.Primitives, "Primitives"},
             {ScreenType.ImGui, "Imgui"},
             {ScreenType.Scaling, "Scaling"},
-            {ScreenType.TextSizes, "memes"},
+            {ScreenType.TextSizes, "Text Sizes"},
         };
 
         public SelectionScreen() => View = new SelectionScreenView(this);

--- a/Wobble.Tests/Screens/Tests/DrawingSprites/TestDrawingSpritesScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/DrawingSprites/TestDrawingSpritesScreenView.cs
@@ -82,7 +82,7 @@ namespace Wobble.Tests.Screens.Tests.DrawingSprites
 #endregion
 
 #region HELLO_WORLD_TEXT
-            HelloWorldText = new SpriteText("exo2-bold", "Hi, how are u", 18)
+            HelloWorldText = new SpriteText("exo2-bold", "Hello, World!", 18)
             {
                 Parent = Container,
                 Alignment = Alignment.TopCenter,
@@ -99,11 +99,11 @@ namespace Wobble.Tests.Screens.Tests.DrawingSprites
                 })
             {
                 Parent = Container,
-                Size = new ScalableVector2(150, 50),
+                Size = new ScalableVector2(200, 50),
                 Tint = Color.Red,
-                Text = { Tint = Color.Black},
+                Text = { Tint = Color.White},
                 Alignment = Alignment.TopCenter,
-                Y = HelloWorldText.Y + 40
+                Y = HelloWorldText.Y + 50
             };
 #endregion
 

--- a/Wobble.Tests/Screens/Tests/DrawingSprites/TestDrawingSpritesScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/DrawingSprites/TestDrawingSpritesScreenView.cs
@@ -82,7 +82,7 @@ namespace Wobble.Tests.Screens.Tests.DrawingSprites
 #endregion
 
 #region HELLO_WORLD_TEXT
-            HelloWorldText = new SpriteText("exo2-bold", "Hello, World!", 18)
+            HelloWorldText = new SpriteText("exo2-bold", "Hi, how are u", 18)
             {
                 Parent = Container,
                 Alignment = Alignment.TopCenter,
@@ -100,7 +100,7 @@ namespace Wobble.Tests.Screens.Tests.DrawingSprites
             {
                 Parent = Container,
                 Size = new ScalableVector2(150, 50),
-                Tint = Color.White,
+                Tint = Color.Red,
                 Text = { Tint = Color.Black},
                 Alignment = Alignment.TopCenter,
                 Y = HelloWorldText.Y + 40

--- a/Wobble.Tests/Screens/Tests/Imgui/TestImGuiScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/Imgui/TestImGuiScreenView.cs
@@ -5,6 +5,7 @@ using Wobble.Assets;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
 using Wobble.Graphics.ImGUI;
+using Wobble.Graphics.Sprites;
 using Wobble.Graphics.UI.Buttons;
 using Wobble.Logging;
 using Wobble.Screens;
@@ -40,8 +41,21 @@ namespace Wobble.Tests.Screens.Tests.Imgui
                 Parent = Container,
                 Alignment = Alignment.MidCenter,
                 Size = new ScalableVector2(100, 100),
-                Tint = Color.Crimson
+                Tint = Color.Crimson,
             };
+
+            // ReSharper disable once ObjectCreationAsStatement
+            var box2 = new Sprite()
+            {
+                Parent = Container,
+                Alignment = Alignment.TopLeft,
+                Size = new ScalableVector2(75, 75),
+                Position = new ScalableVector2(0, 400),
+                Tint = Color.Red,
+                Rotation = 60
+            };
+
+            box2.MoveToX(1200, Easing.OutQuint, 4000);
         }
 
         /// <inheritdoc />
@@ -80,7 +94,7 @@ namespace Wobble.Tests.Screens.Tests.Imgui
             }
             else
             {
-                Box.Tint = Color.Red;
+                Box.Tint = Color.Crimson;
             }
 
             GameBase.Game.GraphicsDevice.Clear(color);

--- a/Wobble.Tests/Wobble.Tests.csproj
+++ b/Wobble.Tests/Wobble.Tests.csproj
@@ -8,6 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MonoGame\MonoGame.Framework\MonoGame.Framework.DesktopGL.Core.csproj" />
+    <ProjectReference Include="..\Wobble.Tests.Assets\Wobble.Tests.Assets.csproj" />
     <ProjectReference Include="..\Wobble.Tests.Resources\Wobble.Tests.Resources.csproj" />
     <ProjectReference Include="..\Wobble\Wobble.csproj" />
   </ItemGroup>

--- a/Wobble.sln
+++ b/Wobble.sln
@@ -13,6 +13,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wobble.Resources", "Wobble.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wobble.Tests.Resources", "Wobble.Tests.Resources\Wobble.Tests.Resources.csproj", "{F7229D04-BC95-462A-863F-B4A4C519EE11}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wobble.Extended", "Wobble.Extended\Wobble.Extended.csproj", "{74F12E62-87ED-4E93-A829-A7E1B06EE0BC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wobble.Tests.Hotload", "Wobble.Tests.Hotload\Wobble.Tests.Hotload.csproj", "{AB46D815-2DA6-452A-9A99-4AF5CF06D19F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wobble.Tests.Assets", "Wobble.Tests.Assets\Wobble.Tests.Assets.csproj", "{758537B2-7192-4E41-A886-835041C7AD24}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +45,18 @@ Global
 		{F7229D04-BC95-462A-863F-B4A4C519EE11}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F7229D04-BC95-462A-863F-B4A4C519EE11}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7229D04-BC95-462A-863F-B4A4C519EE11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74F12E62-87ED-4E93-A829-A7E1B06EE0BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74F12E62-87ED-4E93-A829-A7E1B06EE0BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74F12E62-87ED-4E93-A829-A7E1B06EE0BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74F12E62-87ED-4E93-A829-A7E1B06EE0BC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB46D815-2DA6-452A-9A99-4AF5CF06D19F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB46D815-2DA6-452A-9A99-4AF5CF06D19F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB46D815-2DA6-452A-9A99-4AF5CF06D19F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB46D815-2DA6-452A-9A99-4AF5CF06D19F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{758537B2-7192-4E41-A886-835041C7AD24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{758537B2-7192-4E41-A886-835041C7AD24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{758537B2-7192-4E41-A886-835041C7AD24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{758537B2-7192-4E41-A886-835041C7AD24}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Allows games that are made with Wobble to create projects that allow for automatically reloading screens when making changes to source code.

For now, it's limited to one specified project and is sufficient as long as asset reloading or making edits to Wobble itself isn't necessary (requires restart).

To test, the project `Wobble.Tests.Hotload` is included, Opening/Closing the screen browser can be done with the tilde (~) key.