### PR TITLE
Add Visual Studio saving support to HotLoader

### DIFF
--- a/Wobble.Extended/HotReload/HotLoader.cs
+++ b/Wobble.Extended/HotReload/HotLoader.cs
@@ -68,13 +68,17 @@ namespace Wobble.Extended.HotReload
             Watcher = new FileSystemWatcher
             {
                 Path = ProjectDirectory,
-                NotifyFilter = NotifyFilters.Size,
+                NotifyFilter = NotifyFilters.LastWrite
+                                 | NotifyFilters.FileName
+                                 | NotifyFilters.DirectoryName
+                                 | NotifyFilters.Size,
                 Filter = filter,
                 EnableRaisingEvents = true,
                 IncludeSubdirectories = true
             };
 
             Watcher.Changed += OnChanged;
+            Watcher.Renamed += OnChanged;
         }
 
         /// <summary>


### PR DESCRIPTION
https://stackoverflow.com/questions/680698/why-doesnt-filesystemwatcher-detect-changes-from-visual-studio