### PR TITLE
Make SpriteTextPlus cached and correctly scaled

### DIFF
--- a/Wobble.Tests/Screens/Selection/SelectionScreen.cs
+++ b/Wobble.Tests/Screens/Selection/SelectionScreen.cs
@@ -32,7 +32,8 @@ namespace Wobble.Tests.Screens.Selection
             {ScreenType.Scaling, "Scaling"},
             {ScreenType.TextSizes, "Text Sizes"},
             {ScreenType.TaskHandler, "Task Handler"},
-            {ScreenType.SpriteTextPlus, "SpriteTextPlus"}
+            {ScreenType.SpriteTextPlus, "SpriteTextPlus"},
+            {ScreenType.ScheduledUpdates, "Scheduled Updates"}
         };
 
         public SelectionScreen() => View = new SelectionScreenView(this);
@@ -60,6 +61,7 @@ namespace Wobble.Tests.Screens.Selection
         Scaling,
         TextSizes,
         TaskHandler,
-        SpriteTextPlus
+        SpriteTextPlus,
+        ScheduledUpdates
     }
 }

--- a/Wobble.Tests/Screens/Selection/SelectionScreenView.cs
+++ b/Wobble.Tests/Screens/Selection/SelectionScreenView.cs
@@ -20,6 +20,7 @@ using Wobble.Tests.Screens.Tests.EasingAnimations;
 using Wobble.Tests.Screens.Tests.Imgui;
 using Wobble.Tests.Screens.Tests.Primitives;
 using Wobble.Tests.Screens.Tests.Scaling;
+using Wobble.Tests.Screens.Tests.ScheduledUpdates;
 using Wobble.Tests.Screens.Tests.Scrolling;
 using Wobble.Tests.Screens.Tests.SpriteMasking;
 using Wobble.Tests.Screens.Tests.SpriteTextPlusNew;
@@ -147,6 +148,9 @@ namespace Wobble.Tests.Screens.Selection
                         break;
                     case ScreenType.SpriteTextPlus:
                         button.Clicked += (o, e) => ScreenManager.ChangeScreen(new TestSpriteTextPlusScreen());
+                        break;
+                    case ScreenType.ScheduledUpdates:
+                        button.Clicked += (o, e) => ScreenManager.ChangeScreen(new TestScheduledUpdatesScreen());
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/Wobble.Tests/Screens/Tests/ScheduledUpdates/TestScheduledUpdatesScreen.cs
+++ b/Wobble.Tests/Screens/Tests/ScheduledUpdates/TestScheduledUpdatesScreen.cs
@@ -7,7 +7,5 @@ namespace Wobble.Tests.Screens.Tests.ScheduledUpdates
         public override ScreenView View { get; protected set; }
 
         public TestScheduledUpdatesScreen() => View = new TestScheduledUpdatesScreenView(this);
-
-
     }
 }

--- a/Wobble.Tests/Screens/Tests/ScheduledUpdates/TestScheduledUpdatesScreen.cs
+++ b/Wobble.Tests/Screens/Tests/ScheduledUpdates/TestScheduledUpdatesScreen.cs
@@ -1,0 +1,13 @@
+using Wobble.Screens;
+
+namespace Wobble.Tests.Screens.Tests.ScheduledUpdates
+{
+    public sealed class TestScheduledUpdatesScreen : Screen
+    {
+        public override ScreenView View { get; protected set; }
+
+        public TestScheduledUpdatesScreen() => View = new TestScheduledUpdatesScreenView(this);
+
+
+    }
+}

--- a/Wobble.Tests/Screens/Tests/ScheduledUpdates/TestScheduledUpdatesScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/ScheduledUpdates/TestScheduledUpdatesScreenView.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Wobble.Assets;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Buttons;
+using Wobble.Input;
+using Wobble.Managers;
+using Wobble.Screens;
+
+namespace Wobble.Tests.Screens.Tests.ScheduledUpdates
+{
+    public class TestScheduledUpdatesScreenView: ScreenView
+    {
+        private SpriteTextPlus Scheduled { get; }
+
+        /// <summary>
+        /// </summary>
+        private bool IsScheduled { get; set; } = true;
+
+        public TestScheduledUpdatesScreenView(Screen screen) : base(screen)
+        {
+            Scheduled = new SpriteTextPlus(FontManager.GetWobbleFont("exo2-semibold"),
+                "", 36)
+            {
+                Alignment = Alignment.TopCenter,
+                Y = 250
+            };
+
+
+            Task.Run(() =>
+            {
+                while (!Scheduled.IsDisposed)
+                {
+                    if (IsScheduled)
+                        Scheduled.ScheduleUpdate(() => Scheduled.Text = $"Scheduled - {DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}");
+                    else
+                        Scheduled.Text = $"Unscheduled - {DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+                }
+            });
+
+            new SpriteText("exo2-semibold", "Press 1 to toggle between scheduled & unscheduled", 32)
+            {
+                Parent = Container,
+                Alignment = Alignment.BotCenter
+            };
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            Container?.Update(gameTime);
+            Scheduled.Update(gameTime);
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.D1))
+                IsScheduled = !IsScheduled;
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            GameBase.Game.GraphicsDevice.Clear(Color.CornflowerBlue);
+            Container?.Draw(gameTime);
+
+            Scheduled.Draw(gameTime);
+        }
+
+        public override void Destroy() => Container?.Destroy();
+    }
+}

--- a/Wobble.Tests/Screens/Tests/ScheduledUpdates/TestScheduledUpdatesScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/ScheduledUpdates/TestScheduledUpdatesScreenView.cs
@@ -31,7 +31,6 @@ namespace Wobble.Tests.Screens.Tests.ScheduledUpdates
                 Y = 250
             };
 
-
             Task.Run(() =>
             {
                 while (!Scheduled.IsDisposed)

--- a/Wobble/Graphics/Drawable.cs
+++ b/Wobble/Graphics/Drawable.cs
@@ -277,12 +277,20 @@ namespace Wobble.Graphics
         /// </summary>
         public PrimitiveLineBatch Border { get; private set; }
 
+        /// <summary>
+        ///    A list of updates that are scheduled to be run at the beginning of <see cref="Update"/>.
+        ///    Should be used for scheduling UI updates from a separate thread.
+        /// </summary>
+        private List<Action> ScheduledUpdates { get; } = new List<Action>();
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
         /// <param name="gameTime"></param>
         public virtual void Update(GameTime gameTime)
         {
+            RunScheduledUpdates();
+
             // Increase the total amount of drawables that were drawn and set the order to the current
             // total.
             TotalDrawn++;
@@ -614,6 +622,55 @@ namespace Wobble.Graphics
         /// </summary>
         /// <returns></returns>
         public bool IsHovered() => GraphicsHelper.RectangleContains(ScreenRectangle, MouseManager.CurrentState.Position);
+
+        /// <summary>
+        ///     Removes all previously scheduled updates, and schedules a new one to run in the next frame
+        /// </summary>
+        /// <param name="action"></param>
+        public void ScheduleUpdate(Action action)
+        {
+            lock (ScheduledUpdates)
+            {
+                ScheduledUpdates.Clear();
+                ScheduledUpdates.Add(action);
+            }
+        }
+
+        /// <summary>
+        ///     Schedules a new update to be run in the next frame, but does not remove previously scheduled updates.
+        /// </summary>
+        /// <param name="action"></param>
+        public void AddScheduledUpdate(Action action)
+        {
+            lock (ScheduledUpdates)
+                ScheduledUpdates.Add(action);
+        }
+
+        /// <summary>
+        ///     Removes all
+        /// </summary>
+        public void RemoveScheduledUpdates()
+        {
+            lock (ScheduledUpdates)
+                ScheduledUpdates.Clear();
+        }
+
+        /// <summary>
+        ///     Runs all updates that are scheduled for this drawable during <see cref="Update"/>
+        /// </summary>
+        private void RunScheduledUpdates()
+        {
+            lock (ScheduledUpdates)
+            {
+                if (ScheduledUpdates.Count == 0)
+                    return;
+
+                foreach (var update in ScheduledUpdates)
+                    update.Invoke();
+
+                ScheduledUpdates.Clear();
+            }
+        }
 
         /// <summary>
         ///     Moves the drawable to an x position.

--- a/Wobble/Graphics/Drawable.cs
+++ b/Wobble/Graphics/Drawable.cs
@@ -665,10 +665,11 @@ namespace Wobble.Graphics
                 if (ScheduledUpdates.Count == 0)
                     return;
 
-                foreach (var update in ScheduledUpdates)
-                    update.Invoke();
-
+                var updates = new List<Action>(ScheduledUpdates);
                 ScheduledUpdates.Clear();
+
+                foreach (var update in updates)
+                    update.Invoke();
             }
         }
 

--- a/Wobble/Graphics/ScalableVector2.cs
+++ b/Wobble/Graphics/ScalableVector2.cs
@@ -29,5 +29,8 @@
         }
 
         public override string ToString() => $"X: {X}, Y: {Y}";
+
+        public static ScalableVector2 operator /(ScalableVector2 lhs, float rhs)
+            => new ScalableVector2(lhs.X.Value / rhs, lhs.Y.Value / rhs, lhs.X.Scale, lhs.Y.Scale);
     }
 }

--- a/Wobble/Graphics/SpriteBatchOptions.cs
+++ b/Wobble/Graphics/SpriteBatchOptions.cs
@@ -34,17 +34,21 @@ namespace Wobble.Graphics
             }
         }
 
-        public Matrix TransformMatrix { get; set; } = WindowManager.Scale;
+        public bool DoNotScale = false;
 
         /// <summary>
         ///     Begins the spritebatch with the specified settings.
         /// </summary>
         public void Begin()
         {
+            Matrix? matrix = WindowManager.Scale;
+            if (DoNotScale)
+                matrix = null;
+
             // ReSharper disable once ArrangeMethodOrOperatorBody
             try
             {
-                GameBase.Game.SpriteBatch.Begin(SortMode, BlendState, SamplerState, DepthStencilState, RasterizerState, Shader?.ShaderEffect, WindowManager.Scale);
+                GameBase.Game.SpriteBatch.Begin(SortMode, BlendState, SamplerState, DepthStencilState, RasterizerState, Shader?.ShaderEffect, matrix);
                 return;
             }
             catch (Exception e)
@@ -52,7 +56,7 @@ namespace Wobble.Graphics
                 GameBase.Game.SpriteBatch.End();
             }
 
-            GameBase.Game.SpriteBatch.Begin(SortMode, BlendState, SamplerState, DepthStencilState, RasterizerState, Shader?.ShaderEffect, WindowManager.Scale);
+            GameBase.Game.SpriteBatch.Begin(SortMode, BlendState, SamplerState, DepthStencilState, RasterizerState, Shader?.ShaderEffect, matrix);
         }
     }
 }

--- a/Wobble/Graphics/Sprites/Sprite.cs
+++ b/Wobble/Graphics/Sprites/Sprite.cs
@@ -53,7 +53,7 @@ namespace Wobble.Graphics.Sprites
         /// <summary>
         ///     The rectangle used to render the sprite.
         /// </summary>
-        public RectangleF RenderRectangle { get; private set; }
+        public RectangleF RenderRectangle { get; set; }
 
         /// <summary>
         ///     The tint this QuaverSprite will inherit.

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
@@ -95,6 +95,8 @@ namespace Wobble.Graphics.Sprites.Text
                 };
 
                 width = Math.Max(width, lineSprite.Width);
+
+                Font.Store.Size = FontSize;
                 height += Font.Store.GetLineHeight();
             }
 

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
@@ -77,12 +77,15 @@ namespace Wobble.Graphics.Sprites.Text
             SetChildrenAlpha = true;
         }
 
+        /// <summary>
+        /// </summary>
         private void RefreshText()
         {
             for (var i = Children.Count - 1; i >= 0; i--)
                 Children[i].Destroy();
 
             float width = 0, height = 0;
+
             foreach (var line in Text.Split('\n'))
             {
                 var lineSprite = new SpriteTextPlusLine(Font, line, FontSize)

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlusLine.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlusLine.cs
@@ -1,39 +1,78 @@
-using SpriteFontPlus;
+using System;
+using System.Diagnostics;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended;
+using Wobble.Assets;
+using Wobble.Logging;
+using Wobble.Window;
 
 namespace Wobble.Graphics.Sprites.Text
 {
     public class SpriteTextPlusLine : Sprite
     {
         /// <summary>
+        ///     The underlying text rendering component.
+        /// </summary>
+        private SpriteTextPlusLineRaw _raw;
+
+        /// <summary>
+        ///     Whether the cached texture needs to be refreshed.
+        /// </summary>
+        private bool _dirty;
+
+        /// <summary>
+        ///     Current WindowManager scale.
+        /// </summary>
+        private float _scale;
+        private float Scale
+        {
+            get => _scale;
+            set
+            {
+                if (_scale == value)
+                    return;
+
+                // Retrieve the original font size (computed with old scale).
+                var fontSize = FontSize;
+
+                _scale = value;
+
+                // Set the font size with the new scale.
+                FontSize = fontSize;
+            }
+        }
+
+        /// <summary>
         ///     The font to be used
         /// </summary>
-        public WobbleFontStore Font { get; }
+        public WobbleFontStore Font { get => _raw.Font; }
 
         /// <summary>
         ///     The pt. font size
         /// </summary>
-        private int _fontSize;
-        public int FontSize
+        public float FontSize
         {
-            get => _fontSize;
+            get => _raw.FontSize / _scale;
             set
             {
-                _fontSize = value;
-                RefreshSize();
+                _raw.FontSize = value * _scale;
+                SetSize();
+                _dirty = true;
             }
         }
 
         /// <summary>
         ///     The text displayed for the font.
         /// </summary>
-        private string _text = "";
         public string Text
         {
-            get => _text;
+            get => _raw.Text;
             set
             {
-                _text = value;
-                RefreshSize();
+                _raw.Text = value;
+                SetSize();
+                _dirty = true;
             }
         }
 
@@ -42,32 +81,134 @@ namespace Wobble.Graphics.Sprites.Text
         /// <param name="font"></param>
         /// <param name="text"></param>
         /// <param name="size"></param>
-        public SpriteTextPlusLine(WobbleFontStore font, string text, int size = 0)
+        public SpriteTextPlusLine(WobbleFontStore font, string text, float size = 0)
         {
-            Font = font;
-            Text = text;
-
-            FontSize = size == 0 ? Font.DefaultSize : size;
+            _scale = GetScale();
+            _raw = new SpriteTextPlusLineRaw(font, text, size * _scale)
+            {
+                SpriteBatchOptions = new SpriteBatchOptions
+                {
+                    DoNotScale = true,
+                    BlendState = BlendState.AlphaBlend
+                }
+            };
+            SetSize();
+            Image = WobbleAssets.WhiteBox;
+            _dirty = true;
         }
 
-        /// <inheritdoc />
         /// <summary>
+        ///     Get the current WindowManager scale and check that it's valid.
         /// </summary>
-        public override void DrawToSpriteBatch()
+        /// <returns></returns>
+        private static float GetScale()
         {
-            if (!Visible)
-                return;
-
-            Font.Store.Size = FontSize;
-            GameBase.Game.SpriteBatch.DrawString(Font.Store, Text, AbsolutePosition, _color);
+            var scale = WindowManager.ScreenScale.X;
+            Debug.Assert(scale > 0, "You're setting up text too early (WindowManager.ScreenScale.X is 0).");
+            return scale;
         }
 
-        private void RefreshSize()
+        /// <summary>
+        ///     Set the component size taking rounding into account.
+        /// </summary>
+        private void SetSize()
         {
-            Font.Store.Size = FontSize;
+            // Round the size the same way it will be rounded during rendering.
+            var (width, height) = _raw.AbsoluteSize;
+            var pixelWidth = Math.Ceiling(width);
+            var pixelHeight = Math.Ceiling(height);
 
-            var (x, y) = Font.Store.MeasureString(Text);
-            Size = new ScalableVector2(x, y);
+            var flooredSize = new ScalableVector2((float) pixelWidth, (float) pixelHeight);
+            Size = flooredSize / _scale;
+        }
+
+        /// <summary>
+        ///     Update the Scale and schedules the component to be rendered into a texture if necessary.
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            Scale = GetScale();
+
+            if (_dirty)
+            {
+                _dirty = false;
+                GameBase.Game.ScheduledRenderTargetDraws.Add(() => Cache(gameTime));
+            }
+
+            base.Update(gameTime);
+        }
+
+        /// <summary>
+        ///     Round the position to align with pixels exactly.
+        /// </summary>
+        protected override void OnRectangleRecalculated()
+        {
+            // Update the render rectangle.
+            var x = ScreenRectangle.X;
+            var y = ScreenRectangle.Y;
+
+            if (Rotation == 0)
+            {
+                // Round the coordinates. Not rounding the coordinates means bad text.
+                var pixelX = (int) (x * WindowManager.ScreenScale.X);
+                var pixelY = (int) (y * WindowManager.ScreenScale.Y);
+
+                x = pixelX / WindowManager.ScreenScale.X;
+                y = pixelY / WindowManager.ScreenScale.Y;
+            }
+
+            // Add Width / 2 and Height / 2 to X, Y because that's what Origin is set to (in the Image setter).
+            RenderRectangle = new RectangleF(x + ScreenRectangle.Width / 2f, y + ScreenRectangle.Height / 2f,
+                ScreenRectangle.Width, ScreenRectangle.Height);
+        }
+
+        /// <summary>
+        ///     Render the text into a texture.
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void Cache(GameTime gameTime)
+        {
+            // Logger.Debug($"Rendering line `{Text}`", LogType.Runtime);
+
+            if (Image != WobbleAssets.WhiteBox)
+            {
+                Image.Dispose();
+                Image = WobbleAssets.WhiteBox;
+            }
+
+            try
+            {
+                GameBase.Game.SpriteBatch.End();
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            var (width, height) = _raw.AbsoluteSize;
+            var pixelWidth = (int) Math.Ceiling(width);
+            var pixelHeight = (int) Math.Ceiling(height);
+
+            if (pixelWidth == 0 || pixelHeight == 0)
+            {
+                Visible = false;
+                return;
+            }
+
+            Visible = true;
+
+            var renderTarget = new RenderTarget2D(GameBase.Game.GraphicsDevice, pixelWidth, pixelHeight, false,
+                GameBase.Game.GraphicsDevice.PresentationParameters.BackBufferFormat, DepthFormat.None);
+
+            GameBase.Game.GraphicsDevice.SetRenderTarget(renderTarget);
+            GameBase.Game.GraphicsDevice.Clear(Color.TransparentBlack);
+            _raw.Draw(gameTime);
+            GameBase.Game.SpriteBatch.End();
+
+            GameBase.Game.GraphicsDevice.SetRenderTarget(null);
+
+            Image = renderTarget;
         }
     }
 }

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlusLineRaw.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlusLineRaw.cs
@@ -1,0 +1,74 @@
+using SpriteFontPlus;
+using Wobble.Window;
+
+namespace Wobble.Graphics.Sprites.Text
+{
+    public class SpriteTextPlusLineRaw : Sprite
+    {
+        /// <summary>
+        ///     The font to be used
+        /// </summary>
+        public WobbleFontStore Font { get; }
+
+        /// <summary>
+        ///     The pt. font size
+        /// </summary>
+        private float _fontSize;
+        public float FontSize
+        {
+            get => _fontSize;
+            set
+            {
+                _fontSize = value;
+                RefreshSize();
+            }
+        }
+
+        /// <summary>
+        ///     The text displayed for the font.
+        /// </summary>
+        private string _text = "";
+        public string Text
+        {
+            get => _text;
+            set
+            {
+                _text = value;
+                RefreshSize();
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="font"></param>
+        /// <param name="text"></param>
+        /// <param name="size"></param>
+        public SpriteTextPlusLineRaw(WobbleFontStore font, string text, float size = 0)
+        {
+            Font = font;
+            Text = text;
+
+            FontSize = size == 0 ? Font.DefaultSize : size;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void DrawToSpriteBatch()
+        {
+            if (!Visible)
+                return;
+
+            Font.Store.Size = FontSize;
+            GameBase.Game.SpriteBatch.DrawString(Font.Store, Text, AbsolutePosition, _color);
+        }
+
+        private void RefreshSize()
+        {
+            Font.Store.Size = FontSize;
+
+            var (x, y) = Font.Store.MeasureString(Text);
+            Size = new ScalableVector2(x, y);
+        }
+    }
+}


### PR DESCRIPTION
Scaled text quality :point_right: :chart_with_upwards_trend: 
FPS :point_right: :chart_with_upwards_trend: 

Design: `SpriteTextPlusLine` was moved into `SpriteTextPlusLineRaw`, and instead `SpriteTextPlusLine` became a wrapper which does correct scaling and caching into a texture (both of these kind of go hand-in-hand).

- 2560×1440 old:
  ![](https://cdn.discordapp.com/attachments/570610404527570945/632174918846513186/unknown.png)

  2560×1440 new:
  ![](https://cdn.discordapp.com/attachments/570610404527570945/632176864789790730/unknown.png)
- 1920×1080 old:
  ![](https://cdn.discordapp.com/attachments/570610404527570945/632180525083262995/2019-10-11-143819.png)

  1920×1080 new (it's the same since scale = 1):
  ![](https://cdn.discordapp.com/attachments/570610404527570945/632180551645659137/2019-10-11-143910.png)
- 1280×720 old:
  ![](https://cdn.discordapp.com/attachments/570610404527570945/632179665213063169/2019-10-11-143502.png)

  1280×720 new:
  ![](https://cdn.discordapp.com/attachments/570610404527570945/632179688772730890/2019-10-11-143359.png)