### PR TITLE
Implement text alignment for SpriteTextPlus

### DIFF
--- a/Wobble.Tests/Screens/Tests/SpriteTextPlusNew/TestSpriteTextPlusScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/SpriteTextPlusNew/TestSpriteTextPlusScreenView.cs
@@ -52,7 +52,7 @@ namespace Wobble.Tests.Screens.Tests.SpriteTextPlusNew
             {
                 Parent = Container,
                 Alignment = Alignment.MidLeft,
-                TextAlignment = TextAlignment.LeftToRight,
+                TextAlignment = TextAlignment.Left
                 X = 20,
                 Y = 100
             };
@@ -64,7 +64,7 @@ namespace Wobble.Tests.Screens.Tests.SpriteTextPlusNew
             {
                 Parent = Container,
                 Alignment = Alignment.MidRight,
-                TextAlignment = TextAlignment.RightToLeft,
+                TextAlignment = TextAlignment.Right,
                 X = -20,
                 Y = 100
             };

--- a/Wobble.Tests/Screens/Tests/SpriteTextPlusNew/TestSpriteTextPlusScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/SpriteTextPlusNew/TestSpriteTextPlusScreenView.cs
@@ -47,6 +47,40 @@ namespace Wobble.Tests.Screens.Tests.SpriteTextPlusNew
             };
 
             cyrillic.AddBorder(Color.Cyan, 2);
+
+            var ltr = new SpriteTextPlus(Font, "This text is aligned from\nleft to right", 22)
+            {
+                Parent = Container,
+                Alignment = Alignment.MidLeft,
+                TextAlignment = TextAlignment.LeftToRight,
+                X = 20,
+                Y = 100
+            };
+
+            ltr.AddBorder(Color.White, 2);
+
+            // ReSharper disable once ObjectCreationAsStatement
+            var rtl = new SpriteTextPlus(Font, "This text is aligned from\nright to left", 22)
+            {
+                Parent = Container,
+                Alignment = Alignment.MidRight,
+                TextAlignment = TextAlignment.RightToLeft,
+                X = -20,
+                Y = 100
+            };
+
+            rtl.AddBorder(Color.White, 2);
+
+            // ReSharper disable once ObjectCreationAsStatement
+            var center = new SpriteTextPlus(Font, "This text is aligned\nin the center", 22)
+            {
+                Parent = Container,
+                Alignment = Alignment.MidCenter,
+                TextAlignment = TextAlignment.Center,
+                Y = 100
+            };
+
+            center.AddBorder(Color.White, 2);
         }
 
         /// <inheritdoc />

--- a/Wobble.Tests/Screens/Tests/SpriteTextPlusNew/TestSpriteTextPlusScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/SpriteTextPlusNew/TestSpriteTextPlusScreenView.cs
@@ -52,7 +52,7 @@ namespace Wobble.Tests.Screens.Tests.SpriteTextPlusNew
             {
                 Parent = Container,
                 Alignment = Alignment.MidLeft,
-                TextAlignment = TextAlignment.Left
+                TextAlignment = TextAlignment.Left,
                 X = 20,
                 Y = 100
             };

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
@@ -72,7 +72,7 @@ namespace Wobble.Graphics.Sprites.Text
         /// <summary>
         ///     The alignment of the text
         /// </summary>
-        private TextAlignment _textAlignment = TextAlignment.LeftToRight;
+        private TextAlignment _textAlignment = TextAlignment.Left;
         public TextAlignment TextAlignment
         {
             get => _textAlignment;
@@ -157,11 +157,11 @@ namespace Wobble.Graphics.Sprites.Text
         {
             switch (TextAlignment)
             {
-                case TextAlignment.LeftToRight:
+                case TextAlignment.Left:
                     return Alignment.TopLeft;
                 case TextAlignment.Center:
                     return Alignment.TopCenter;
-                case TextAlignment.RightToLeft:
+                case TextAlignment.Right:
                     return Alignment.TopRight;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
@@ -114,7 +114,7 @@ namespace Wobble.Graphics.Sprites.Text
                 var lineSprite = new SpriteTextPlusLine(Font, line, FontSize)
                 {
                     Parent = this,
-                    Alignment = ConvertTextAlignmment(),
+                    Alignment = ConvertTextAlignment(),
                     Y = height,
                     UsePreviousSpriteBatchOptions = true,
                     Tint = Tint,
@@ -153,7 +153,7 @@ namespace Wobble.Graphics.Sprites.Text
         /// </summary>
         /// <returns></returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        private Alignment ConvertTextAlignmment()
+        private Alignment ConvertTextAlignment()
         {
             switch (TextAlignment)
             {

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
@@ -70,6 +70,23 @@ namespace Wobble.Graphics.Sprites.Text
         }
 
         /// <summary>
+        ///     The alignment of the text
+        /// </summary>
+        private TextAlignment _textAlignment = TextAlignment.LeftToRight;
+        public TextAlignment TextAlignment
+        {
+            get => _textAlignment;
+            set
+            {
+                if (value == _textAlignment)
+                    return;
+
+                _textAlignment = value;
+                RefreshText();
+            }
+        }
+
+        /// <summary>
         /// </summary>
         /// <param name="font"></param>
         /// <param name="text"></param>
@@ -97,10 +114,11 @@ namespace Wobble.Graphics.Sprites.Text
                 var lineSprite = new SpriteTextPlusLine(Font, line, FontSize)
                 {
                     Parent = this,
+                    Alignment = ConvertTextAlignmment(),
                     Y = height,
                     UsePreviousSpriteBatchOptions = true,
                     Tint = Tint,
-                    Alpha = Alpha
+                    Alpha = Alpha,
                 };
 
                 width = Math.Max(width, lineSprite.Width);
@@ -129,6 +147,25 @@ namespace Wobble.Graphics.Sprites.Text
 
         public override void DrawToSpriteBatch()
         {
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private Alignment ConvertTextAlignmment()
+        {
+            switch (TextAlignment)
+            {
+                case TextAlignment.LeftToRight:
+                    return Alignment.TopLeft;
+                case TextAlignment.Center:
+                    return Alignment.TopCenter;
+                case TextAlignment.RightToLeft:
+                    return Alignment.TopRight;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
     }
 }

--- a/Wobble/Graphics/Sprites/Text/TextAlignment.cs
+++ b/Wobble/Graphics/Sprites/Text/TextAlignment.cs
@@ -2,8 +2,8 @@ namespace Wobble.Graphics.Sprites.Text
 {
     public enum TextAlignment
     {
-        LeftToRight,
+        Left,
         Center,
-        RightToLeft
+        Right
     }
 }

--- a/Wobble/Graphics/Sprites/Text/TextAlignment.cs
+++ b/Wobble/Graphics/Sprites/Text/TextAlignment.cs
@@ -1,0 +1,9 @@
+namespace Wobble.Graphics.Sprites.Text
+{
+    public enum TextAlignment
+    {
+        LeftToRight,
+        Center,
+        RightToLeft
+    }
+}


### PR DESCRIPTION
Adds a `TextAlignment` property to SpriteTextPlus to allow new lines to be aligned from left-to-right, right-to-left, or centered.

![image](https://user-images.githubusercontent.com/20389565/67120397-37dc3b80-f1b7-11e9-924f-b9a9c4028eb6.png)
