### PR TITLE
TaskHandler: call OnCompleted outside of the lock

### DIFF
--- a/Wobble/Scheduling/TaskHandler.cs
+++ b/Wobble/Scheduling/TaskHandler.cs
@@ -91,10 +91,12 @@ namespace Wobble.Scheduling
                         token.ThrowIfCancellationRequested();
                         IsCompleted = true;
                         IsRunning = false;
-
-                        OnCompleted?.Invoke(typeof(TaskHandler<T, TResult>),
-                            new TaskCompleteEventArgs<T, TResult>(input, result));
                     }
+
+                    // Invoke the callback outside of the lock to avoid accidental deadlocks
+                    // caused by the callback code.
+                    OnCompleted?.Invoke(typeof(TaskHandler<T, TResult>),
+                        new TaskCompleteEventArgs<T, TResult>(input, result));
                 }
                 catch (OperationCanceledException e)
                 {


### PR DESCRIPTION
Should fix the song select freeze. Also now that no user code is called under the locks, there's nothing more to deadlock in TaskHandler.