### PR TITLE
Misc linux fixes

### DIFF
--- a/Wobble/Platform/Linux/LinuxUtils.cs
+++ b/Wobble/Platform/Linux/LinuxUtils.cs
@@ -11,9 +11,17 @@ namespace Wobble.Platform.Linux
     {
         public override void HighlightInFileManager(string path)
         {
-            // There isn't really a standard way of doing this on Linux, so fall back to just opening the containing
-            // folder.
-            OpenNatively(Path.GetDirectoryName(path));
+            try
+            {
+                // Try launching nautilus (GNOME's file manager) first as it can highlight a file by path.
+                Process.Start("nautilus", path);
+            }
+            catch (Win32Exception)
+            {
+                // There isn't really a standard way of doing this on Linux, so fall back to just opening the containing
+                // folder.
+                OpenNatively(Path.GetDirectoryName(path));
+            }
         }
 
         public override void OpenNatively(string path)

--- a/Wobble/Platform/Linux/LinuxUtils.cs
+++ b/Wobble/Platform/Linux/LinuxUtils.cs
@@ -16,7 +16,7 @@ namespace Wobble.Platform.Linux
                 // Try launching nautilus (GNOME's file manager) first as it can highlight a file by path.
                 Process.Start("nautilus", path);
             }
-            catch (Win32Exception)
+            catch (Exception)
             {
                 // There isn't really a standard way of doing this on Linux, so fall back to just opening the containing
                 // folder.
@@ -31,7 +31,7 @@ namespace Wobble.Platform.Linux
                 // Try opening via xdg-open.
                 Process.Start("xdg-open", path);
             }
-            catch (Win32Exception)
+            catch (Exception)
             {
                 // No xdg-open? Oh well.
             }
@@ -64,7 +64,7 @@ namespace Wobble.Platform.Linux
             {
                 Process.Start("xdg-mime", $"default {friendlyName}.desktop x-scheme-handler/{scheme}");
             }
-            catch (Win32Exception)
+            catch (Exception)
             {
                 // No xdg-mime? Oh well.
             }

--- a/Wobble/Platform/Linux/LinuxUtils.cs
+++ b/Wobble/Platform/Linux/LinuxUtils.cs
@@ -34,6 +34,9 @@ namespace Wobble.Platform.Linux
             // This returns Something.dll, on Linux the published executable is usually called Something.
             var applicationLocation = Path.ChangeExtension(Assembly.GetEntryAssembly().Location, null);
 
+            // Just "friendlyName" is taken by Steam's own shortcut to the game.
+            friendlyName = friendlyName + "-scheme-handler";
+
             var dataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME") ?? Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".local/share");
             var desktopFilePath = Path.Combine(dataHome, $"applications/{friendlyName}.desktop");
 


### PR DESCRIPTION
- Changed the scheme-handler shortcut name so it doesn't overwrite Steam's Quaver shortcut.
- Made HighlightInFileManager try opening nautilus (GNOME's file manager) first as it supports file highlighting.