### PR TITLE
LinuxUtils: use ProcessStartInfo

### DIFF
--- a/Wobble/Platform/Linux/LinuxUtils.cs
+++ b/Wobble/Platform/Linux/LinuxUtils.cs
@@ -14,7 +14,11 @@ namespace Wobble.Platform.Linux
             try
             {
                 // Try launching nautilus (GNOME's file manager) first as it can highlight a file by path.
-                Process.Start("nautilus", path);
+                var info = new ProcessStartInfo("nautilus")
+                {
+                    ArgumentList = {path}
+                };
+                Process.Start(info);
             }
             catch (Exception)
             {
@@ -29,7 +33,11 @@ namespace Wobble.Platform.Linux
             try
             {
                 // Try opening via xdg-open.
-                Process.Start("xdg-open", path);
+                var info = new ProcessStartInfo("xdg-open")
+                {
+                    ArgumentList = {path}
+                };
+                Process.Start(info);
             }
             catch (Exception)
             {


### PR DESCRIPTION
This allows to avoid unintended argument splitting on spaces, etc.

Fixes https://github.com/Quaver/Quaver/issues/2489