### PR TITLE
make Ctrl+Backspace act as Backspace when selected

### DIFF
--- a/Wobble/Graphics/UI/Form/Textbox.cs
+++ b/Wobble/Graphics/UI/Form/Textbox.cs
@@ -500,11 +500,19 @@ namespace Wobble.Graphics.UI.Form
             // This means killing all trailing whitespace and then all trailing non-whitespace.
             if (KeyboardManager.IsUniqueKeyPress(Keys.W) || KeyboardManager.IsUniqueKeyPress(Keys.Back))
             {
-                var withoutTrailingWhitespace = RawText.TrimEnd();
-                var nonWhitespacesInTheEnd = withoutTrailingWhitespace.ToCharArray()
-                    .Select(c => c).Reverse().TakeWhile(c => !char.IsWhiteSpace(c)).Count();
-                RawText = withoutTrailingWhitespace.Substring(0,
-                    withoutTrailingWhitespace.Length - nonWhitespacesInTheEnd);
+                if (Selected)
+                {
+                    // When everything is selected we act as a normal backspace and delete everything
+                    RawText = "";
+                }
+                else
+                {
+                    var withoutTrailingWhitespace = RawText.TrimEnd();
+                    var nonWhitespacesInTheEnd = withoutTrailingWhitespace.ToCharArray()
+                        .Select(c => c).Reverse().TakeWhile(c => !char.IsWhiteSpace(c)).Count();
+                    RawText = withoutTrailingWhitespace.Substring(0,
+                        withoutTrailingWhitespace.Length - nonWhitespacesInTheEnd);
+                }
 
                 ReadjustTextbox();
                 Selected = false;


### PR DESCRIPTION
Currently only the last word is deleted even when all text is selected. This is easy to run into, as if you try to do Ctrl+A, then Backspace quickly, you will eventually accidentally hold Ctrl while pressing Backspace.
This pull request makes it match Windows and Linux (GTK) behavior (and maybe others).