### PR TITLE
Fix crash due to threaded access to AudioManager.Tracks

### DIFF
--- a/Wobble/Audio/AudioManager.cs
+++ b/Wobble/Audio/AudioManager.cs
@@ -71,32 +71,35 @@ namespace Wobble.Audio
         /// </summary>
         private static void UpdateTracks(GameTime gameTime)
         {
-            for (var i = Tracks.Count - 1; i >= 0; i--)
+            lock (Tracks)
             {
-                if (i > Tracks.Count)
-                    break;
-
-                var track = Tracks[i];
-
-                // If the track is left over, we just want to dispose of it and remove it from our tracks.
-                if (track is AudioTrack t)
+                for (var i = Tracks.Count - 1; i >= 0; i--)
                 {
-                    if ((t.IsLeftOver && t.AutoDispose) || t.IsDisposed)
-                    {
-                        Tracks.Remove(t);
-                        continue;
-                    }
-                }
+                    if (i > Tracks.Count)
+                        break;
 
-                if (track is AudioTrackVirtual atv)
-                {
-                    if (atv.IsDisposed)
+                    var track = Tracks[i];
+
+                    // If the track is left over, we just want to dispose of it and remove it from our tracks.
+                    if (track is AudioTrack t)
                     {
-                        Tracks.Remove(atv);
-                        continue;
+                        if ((t.IsLeftOver && t.AutoDispose) || t.IsDisposed)
+                        {
+                            Tracks.Remove(t);
+                            continue;
+                        }
                     }
 
-                    atv.Update(gameTime);
+                    if (track is AudioTrackVirtual atv)
+                    {
+                        if (atv.IsDisposed)
+                        {
+                            Tracks.Remove(atv);
+                            continue;
+                        }
+
+                        atv.Update(gameTime);
+                    }
                 }
             }
         }

--- a/Wobble/Audio/AudioManager.cs
+++ b/Wobble/Audio/AudioManager.cs
@@ -81,11 +81,8 @@ namespace Wobble.Audio
                 // If the track is left over, we just want to dispose of it and remove it from our tracks.
                 if (track is AudioTrack t)
                 {
-                    if (t.IsLeftOver && t.AutoDispose)
+                    if ((t.IsLeftOver && t.AutoDispose) || t.IsDisposed)
                     {
-                        if (!t.IsDisposed)
-                            t.Dispose();
-
                         Tracks.Remove(t);
                         continue;
                     }

--- a/Wobble/Audio/Tracks/AudioTrack.cs
+++ b/Wobble/Audio/Tracks/AudioTrack.cs
@@ -392,7 +392,8 @@ namespace Wobble.Audio.Tracks
             if (!StreamLoaded)
                 throw new AudioEngineException("Cannot call AfterLoad if stream isn't loaded.");
 
-            AudioManager.Tracks.Add(this);
+            lock (AudioManager.Tracks)
+                AudioManager.Tracks.Add(this);
 
             Length = Bass.ChannelBytes2Seconds(Stream,Bass.ChannelGetLength(Stream)) * 1000;
             Frequency = Bass.ChannelGetInfo(Stream).Frequency;

--- a/Wobble/Audio/Tracks/AudioTrack.cs
+++ b/Wobble/Audio/Tracks/AudioTrack.cs
@@ -381,8 +381,6 @@ namespace Wobble.Audio.Tracks
             IsDisposed = true;
             Seeked = null;
             RateChanged = null;
-
-            AudioManager.Tracks.Remove(this);
         }
 
         /// <summary>

--- a/Wobble/Audio/Tracks/AudioTrackVirtual.cs
+++ b/Wobble/Audio/Tracks/AudioTrackVirtual.cs
@@ -95,7 +95,9 @@ namespace Wobble.Audio.Tracks
         public AudioTrackVirtual(double length)
         {
             Length = length;
-            AudioManager.Tracks.Add(this);
+
+            lock (AudioManager.Tracks)
+                AudioManager.Tracks.Add(this);
         }
 
         /// <summary>


### PR DESCRIPTION
Should fix crashes like this:
```
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.Collections.Generic.List`1.RemoveAt(Int32 index)
   at System.Collections.Generic.List`1.Remove(T item)
   at Wobble.Audio.Tracks.AudioTrack.Dispose() in C:\Users\Swan\Desktop\git\Quaver\Wobble\Wobble\Audio\Tracks\AudioTrack.cs:line 386
   at Wobble.Audio.AudioManager.UpdateTracks(GameTime gameTime) in C:\Users\Swan\Desktop\git\Quaver\Wobble\Wobble\Audio\AudioManager.cs:line 87
   at Wobble.WobbleGame.Update(GameTime gameTime) in C:\Users\Swan\Desktop\git\Quaver\Wobble\Wobble\WobbleGame.cs:line 208
   at Quaver.Shared.QuaverGame.Update(GameTime gameTime) in C:\Users\Swan\Desktop\git\Quaver\Quaver.Shared\QuaverGame.cs:line 335
   at Microsoft.Xna.Framework.Game.DoUpdate(GameTime gameTime) in C:\Users\Swan\Desktop\git\Quaver\Wobble\MonoGame\MonoGame.Framework\Game.cs:line 686
   at Microsoft.Xna.Framework.Game.Tick() in C:\Users\Swan\Desktop\git\Quaver\Wobble\MonoGame\MonoGame.Framework\Game.cs:line 531
   at Microsoft.Xna.Framework.SdlGamePlatform.RunLoop() in C:\Users\Swan\Desktop\git\Quaver\Wobble\MonoGame\MonoGame.Framework\Platform\SDL\SDLGamePlatform.cs:line 195
   at Microsoft.Xna.Framework.Game.Run(GameRunBehavior runBehavior) in C:\Users\Swan\Desktop\git\Quaver\Wobble\MonoGame\MonoGame.Framework\Game.cs:line 425
   at Microsoft.Xna.Framework.Game.Run() in C:\Users\Swan\Desktop\git\Quaver\Wobble\MonoGame\MonoGame.Framework\Game.cs:line 395
   at Quaver.Program.Run() in C:\Users\Swan\Desktop\git\Quaver\Quaver\Program.cs:line 114
   at Quaver.Program.Main(String[] args) in C:\Users\Swan\Desktop\git\Quaver\Quaver\Program.cs:line 63
```