### PR TITLE
Button: Use default value instead of exception

### DIFF
--- a/Wobble/Graphics/UI/Buttons/Button.cs
+++ b/Wobble/Graphics/UI/Buttons/Button.cs
@@ -123,14 +123,10 @@ namespace Wobble.Graphics.UI.Buttons
                 IsHoveredWithoutDrawOrder = true;
 
                 // Get the button that is on the top layer.
-                Button topLayerButton;
+                var topLayerButton = ButtonManager.Buttons.FindAll(x => x.IsHoveredWithoutDrawOrder && x.IsClickable && IsGloballyClickable)
+                    .OrderBy(x => x.Depth).ThenByDescending(x => x.DrawOrder).DefaultIfEmpty(null).First();
 
-                try
-                {
-                    topLayerButton = ButtonManager.Buttons.FindAll(x => x.IsHoveredWithoutDrawOrder && x.IsClickable && IsGloballyClickable)
-                        .OrderBy(x => x.Depth).ThenByDescending(x => x.DrawOrder).First();
-                }
-                catch (Exception e)
+                if (topLayerButton == null)
                 {
                     base.Update(gameTime);
                     return;


### PR DESCRIPTION
Exception is really costly and was showing up at the top of the profiling stack during gameplay because the pause screen calls that function every frame.