### PR TITLE
Add parameter to loop between 2 frames

### DIFF
--- a/Wobble/Graphics/Sprites/AnimatableSprite.cs
+++ b/Wobble/Graphics/Sprites/AnimatableSprite.cs
@@ -23,12 +23,12 @@ namespace Wobble.Graphics.Sprites
         public int CurrentFrame { get; private set; }
 
         /// <summary>
-        ///     
+        ///     The frame the animation start from.
         /// </summary>
         public int DefaultFrame { get; set; }
 
         /// <summary>
-        ///     
+        ///     The last frame of the animation.
         /// </summary>
         public int LastFrame { get; private set; }
 

--- a/Wobble/Graphics/Sprites/AnimatableSprite.cs
+++ b/Wobble/Graphics/Sprites/AnimatableSprite.cs
@@ -25,12 +25,22 @@ namespace Wobble.Graphics.Sprites
         /// <summary>
         ///     The frame the animation start from.
         /// </summary>
-        public int DefaultFrame { get; set; }
+        public int FirstFrame { get; set; }
 
         /// <summary>
         ///     The last frame of the animation.
         /// </summary>
         public int LastFrame { get; private set; }
+
+        /// <summary>
+        ///     The numbers of row in the sheet.
+        /// </summary>
+        public int Rows { get; set; }
+
+        /// <summary>
+        ///     The numbers of column in the sheet.
+        /// </summary>
+        public int Columns { get; set; }
 
         /// <summary>
         ///     If the animation is currently looping.
@@ -127,7 +137,7 @@ namespace Wobble.Graphics.Sprites
         public void ChangeToNext()
         {
             if (CurrentFrame + 1 > LastFrame - 1)
-                CurrentFrame = DefaultFrame;
+                CurrentFrame = FirstFrame;
             else
                 CurrentFrame++;
 
@@ -139,7 +149,7 @@ namespace Wobble.Graphics.Sprites
         /// </summary>
         public void ChangeToPrevious()
         {
-            if (CurrentFrame - 1 < DefaultFrame)
+            if (CurrentFrame - 1 < FirstFrame)
                 CurrentFrame = LastFrame - 1;
             else
                 CurrentFrame--;
@@ -186,7 +196,7 @@ namespace Wobble.Graphics.Sprites
             Direction = direction;
             LoopFramesPerSecond = fps;
             IsLooping = true;
-            CurrentFrame = DefaultFrame;
+            CurrentFrame = FirstFrame;
             FrameLoopStartedOn = CurrentFrame;
             TimesLooped = 0;
             TimesToLoop = timesToLoop;

--- a/Wobble/Graphics/Sprites/AnimatableSprite.cs
+++ b/Wobble/Graphics/Sprites/AnimatableSprite.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -21,6 +21,16 @@ namespace Wobble.Graphics.Sprites
         ///     The current animation frame we're on.
         /// </summary>
         public int CurrentFrame { get; private set; }
+
+        /// <summary>
+        ///     
+        /// </summary>
+        public int DefaultFrame { get; set; }
+
+        /// <summary>
+        ///     
+        /// </summary>
+        public int LastFrame { get; private set; }
 
         /// <summary>
         ///     If the animation is currently looping.
@@ -73,6 +83,7 @@ namespace Wobble.Graphics.Sprites
         {
             Frames = AssetLoader.LoadSpritesheetFromTexture(spritesheet, rows, columns);
             Image = Frames[CurrentFrame];
+            LastFrame = Frames.Count;
         }
 
         /// <inheritdoc />
@@ -84,6 +95,7 @@ namespace Wobble.Graphics.Sprites
         {
             Frames = frames;
             Image = Frames[CurrentFrame];
+            LastFrame = Frames.Count;
         }
 
         /// <inheritdoc />
@@ -114,8 +126,8 @@ namespace Wobble.Graphics.Sprites
         /// </summary>
         public void ChangeToNext()
         {
-            if (CurrentFrame + 1 > Frames.Count - 1)
-                CurrentFrame = 0;
+            if (CurrentFrame + 1 > LastFrame - 1)
+                CurrentFrame = DefaultFrame;
             else
                 CurrentFrame++;
 
@@ -127,8 +139,8 @@ namespace Wobble.Graphics.Sprites
         /// </summary>
         public void ChangeToPrevious()
         {
-            if (CurrentFrame - 1 < 0)
-                CurrentFrame = Frames.Count - 1;
+            if (CurrentFrame - 1 < DefaultFrame)
+                CurrentFrame = LastFrame - 1;
             else
                 CurrentFrame--;
 
@@ -169,14 +181,17 @@ namespace Wobble.Graphics.Sprites
         /// <param name="direction"></param>
         /// <param name="fps"></param>
         /// <param name="timesToLoop">The amount of times to loop. If 0, it'll loop infinitely.</param>
-        public void StartLoop(Direction direction, int fps, int timesToLoop = 0)
+        public void StartLoop(Direction direction, int fps, int timesToLoop = 0, int lastFrame = 0)
         {
             Direction = direction;
             LoopFramesPerSecond = fps;
             IsLooping = true;
+            CurrentFrame = DefaultFrame;
             FrameLoopStartedOn = CurrentFrame;
             TimesLooped = 0;
             TimesToLoop = timesToLoop;
+            if (lastFrame != 0)
+                LastFrame = lastFrame;
         }
 
         /// <summary>


### PR DESCRIPTION
This add the ability to loop between 2 specific frames.

For example, if there is 30 frames, it now become possible loop between frame 10 to 20, and ignore all the other frames.

This can be useful in case of a spritesheet from which the rows would be animation, and the column a parameter.

In the case of Quaver, it could be used for the hitobjectspritesheet, where the column are the color, and the rows are the animation.