### PR TITLE
Use SpriteSortMode.Deferred instead of Immediate

### DIFF
--- a/Wobble/GameBase.cs
+++ b/Wobble/GameBase.cs
@@ -32,7 +32,7 @@ namespace Wobble
         /// </summary>
         public static SpriteBatchOptions DefaultSpriteBatchOptions { get; set; } = new SpriteBatchOptions()
         {
-            SortMode = SpriteSortMode.Immediate,
+            SortMode = SpriteSortMode.Deferred,
             BlendState = BlendState.NonPremultiplied,
         };
 

--- a/Wobble/Graphics/SpriteBatchOptions.cs
+++ b/Wobble/Graphics/SpriteBatchOptions.cs
@@ -12,7 +12,7 @@ namespace Wobble.Graphics
     /// </summary>
     public class SpriteBatchOptions
     {
-        public SpriteSortMode SortMode { get; set; } = SpriteSortMode.Immediate;
+        public SpriteSortMode SortMode { get; set; } = SpriteSortMode.Deferred;
         public BlendState BlendState { get; set; } = BlendState.NonPremultiplied;
         public SamplerState SamplerState { get; set; } = SamplerState.LinearClamp;
         public DepthStencilState DepthStencilState { get; set; }

--- a/Wobble/Graphics/Sprites/ScrollContainer.cs
+++ b/Wobble/Graphics/Sprites/ScrollContainer.cs
@@ -82,7 +82,7 @@ namespace Wobble.Graphics.Sprites
             // Create the SpriteBatchOptions with scissor rect enabled.
             SpriteBatchOptions = new SpriteBatchOptions
             {
-                SortMode = SpriteSortMode.Immediate,
+                SortMode = SpriteSortMode.Deferred,
                 BlendState = BlendState.NonPremultiplied,
                 RasterizerState = new RasterizerState
                 {


### PR DESCRIPTION
Should improve performance - especially on lower end machines, as `SpriteSortMode.Immediate` completely disabled batching. Deferred should give the same result as far as draw order goes, but needs more testing to see if there is any unintended changes.

@YaLTeR You sent [this](https://cdn.discordapp.com/attachments/489247529628860427/862014709162704906/unknown.png) before. Any way you can do a before/after to see if there's any difference?