### PR TITLE
Improve scrolling methods of scroll containers

### DIFF
--- a/Wobble/Graphics/Sprites/ScrollContainer.cs
+++ b/Wobble/Graphics/Sprites/ScrollContainer.cs
@@ -155,7 +155,7 @@ namespace Wobble.Graphics.Sprites
             // Scrollbar Dragging
             if (AllowScrollbarDragging)
             {
-                if (AllowScrollbarDragging && !IsScrollbarDragging && MouseManager.IsUniquePress(MouseButton.Left) && Scrollbar.IsHovered())
+                if (InputEnabled && !IsScrollbarDragging && MouseManager.IsUniquePress(MouseButton.Left) && Scrollbar.IsHovered())
                 {
                     IsScrollbarDragging = true;
                     ScrollbarDraggingOffset = Scrollbar.ScreenRectangle.Y - MouseManager.CurrentState.Position.Y;
@@ -178,11 +178,12 @@ namespace Wobble.Graphics.Sprites
                     TargetY = -ContentContainer.Height * percent;
                 }
             }
-            // Middle mouse scrolling
+
+            // Middle mouse button dragging
             if (AllowMiddleMouseDragging && !IsScrollbarDragging)
             {
                 IsMiddleMouseDragging = MouseManager.CurrentState.MiddleButton == ButtonState.Pressed &&
-                                        (IsHovered() || IsMiddleMouseDragging);
+                                        ((IsHovered() && InputEnabled) || IsMiddleMouseDragging);
 
                 if (IsMiddleMouseDragging)
                 {
@@ -190,7 +191,8 @@ namespace Wobble.Graphics.Sprites
                     TargetY = -ContentContainer.Height * percent;
                 }
             }
-            // Other scrolling
+
+            // Scroll wheel scrolling
             if (InputEnabled && !IsScrollbarDragging && !IsMiddleMouseDragging)
             {
                 if (MouseManager.CurrentState.ScrollWheelValue > MouseManager.PreviousState.ScrollWheelValue)

--- a/Wobble/Graphics/Sprites/ScrollContainer.cs
+++ b/Wobble/Graphics/Sprites/ScrollContainer.cs
@@ -153,7 +153,7 @@ namespace Wobble.Graphics.Sprites
                 Scrollbar.Height = 30;
 
             // Scrollbar Dragging
-            if (AllowScrollbarDragging)
+            if (AllowScrollbarDragging && !IsMiddleMouseDragging)
             {
                 if (InputEnabled && !IsScrollbarDragging && MouseManager.IsUniquePress(MouseButton.Left) && Scrollbar.IsHovered())
                 {
@@ -162,18 +162,11 @@ namespace Wobble.Graphics.Sprites
                 }
                 else
                 {
-                    IsScrollbarDragging = AllowScrollbarDragging && IsScrollbarDragging &&
-                                            MouseManager.CurrentState.LeftButton == ButtonState.Pressed;
+                    IsScrollbarDragging = IsScrollbarDragging && MouseManager.CurrentState.LeftButton == ButtonState.Pressed;
                 }
 
                 if (IsScrollbarDragging)
                 {
-                    // Scrollbar.Y = MathHelper.Clamp(MouseManager.CurrentState.Position.Y + ScrollbarDraggingOffset,
-                    //                                Scrollbar.Parent.Y, Scrollbar.Parent.Y + Scrollbar.Parent.Height);
-
-                    // var percent = Scrollbar.Y / Scrollbar.Parent.Height;
-                    // TargetY = -ContentContainer.Height * percent;
-
                     var percent = (MouseManager.CurrentState.Position.Y + ScrollbarDraggingOffset - Scrollbar.Parent.ScreenRectangle.Y) / Scrollbar.Parent.Height;
                     TargetY = -ContentContainer.Height * percent;
                 }

--- a/Wobble/Graphics/Sprites/ScrollContainer.cs
+++ b/Wobble/Graphics/Sprites/ScrollContainer.cs
@@ -23,6 +23,11 @@ namespace Wobble.Graphics.Sprites
         public Sprite Scrollbar { get; }
 
         /// <summary>
+        ///     Keeps track of whether the user is dragging to allow for continued dragging outside normal bounds
+        /// </summary>
+        public bool IsMiddleMouseDragging { get; private set; } = false;
+
+        /// <summary>
         ///     The target y position of the container.
         /// </summary>
         public float TargetY { get; set;  }
@@ -127,16 +132,21 @@ namespace Wobble.Graphics.Sprites
             if (Scrollbar.Height < 30)
                 Scrollbar.Height = 30;
 
-            // Handle scrolling
-            if (InputEnabled)
+            // Middle mouse scrolling
+            IsMiddleMouseDragging = AllowMiddleMouseDragging &&
+                                    MouseManager.CurrentState.MiddleButton == ButtonState.Pressed &&
+                                    (IsHovered() || IsMiddleMouseDragging);
+
+            if (IsMiddleMouseDragging)
             {
-                // Middle mouse scrolling
-                if (IsHovered() && AllowMiddleMouseDragging && MouseManager.CurrentState.MiddleButton == ButtonState.Pressed)
-                {
-                    var percent = MathHelper.Clamp((MouseManager.CurrentState.Y - ScreenRectangle.Y) / ScreenRectangle.Height, 0, 1);
-                    TargetY = -ContentContainer.Height * percent;
-                }
-                else if (MouseManager.CurrentState.ScrollWheelValue > MouseManager.PreviousState.ScrollWheelValue)
+                var percent = MathHelper.Clamp((MouseManager.CurrentState.Y - ScreenRectangle.Y) / ScreenRectangle.Height, 0, 1);
+                TargetY = -ContentContainer.Height * percent;
+            }
+
+            // Handle scrolling
+            if (InputEnabled && !IsMiddleMouseDragging)
+            {
+                if (MouseManager.CurrentState.ScrollWheelValue > MouseManager.PreviousState.ScrollWheelValue)
                     TargetY += ScrollSpeed;
                 else if (MouseManager.CurrentState.ScrollWheelValue < MouseManager.PreviousState.ScrollWheelValue)
                     TargetY -= ScrollSpeed;


### PR DESCRIPTION
1. Allow dragging out of normal bounds while holding down middle click, making scrolling to the top or bottom of a scroll container more reliable when moving the mouse quickly.

2. Allow scrolling by dragging on the scrollbar.