### PR TITLE
fix cursor wrong pos when !AllowCursorMovement

### DIFF
--- a/Wobble/Graphics/UI/Form/Textbox.cs
+++ b/Wobble/Graphics/UI/Form/Textbox.cs
@@ -69,6 +69,9 @@ namespace Wobble.Graphics.UI.Form
                     InputText.Alpha = 1;
                 }
 
+                if (!AllowCursorMovement)
+                    CursorPosition = RawText.Length;
+
                 ChangeCursorLocation();
             }
         }


### PR DESCRIPTION
noticeable on downloading screen when accepting recommended difficulty