### PR TITLE
Add the ability to change scrolling inversion

### DIFF
--- a/Wobble.Tests/Screens/Tests/Audio/TestAudioScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/Audio/TestAudioScreenView.cs
@@ -156,9 +156,9 @@ namespace Wobble.Tests.Screens.Tests.Audio
                         song.Play();
                 }
 
-                if (MouseManager.CurrentState.ScrollWheelValue > MouseManager.PreviousState.ScrollWheelValue)
+                if (MouseManager.IsScrollingUp())
                     song.Volume += 9;
-                else if (MouseManager.CurrentState.ScrollWheelValue < MouseManager.PreviousState.ScrollWheelValue)
+                else if (MouseManager.IsScrollingDown())
                     song.Volume -= 9;
             }
 

--- a/Wobble/Graphics/Sprites/ScrollContainer.cs
+++ b/Wobble/Graphics/Sprites/ScrollContainer.cs
@@ -211,9 +211,9 @@ namespace Wobble.Graphics.Sprites
             // Scroll wheel scrolling
             if (InputEnabled && !IsScrollbarDragging && !IsMiddleMouseDragging)
             {
-                if (MouseManager.CurrentState.ScrollWheelValue > MouseManager.PreviousState.ScrollWheelValue)
+                if (MouseManager.IsScrollingUp(InvertedScrolling))
                     TargetY += ScrollSpeed;
-                else if (MouseManager.CurrentState.ScrollWheelValue < MouseManager.PreviousState.ScrollWheelValue)
+                else if (MouseManager.IsScrollingDown(InvertedScrolling))
                     TargetY -= ScrollSpeed;
                 else if (KeyboardManager.IsUniqueKeyPress(Keys.PageUp))
                     TargetY += ScrollSpeed * 5;

--- a/Wobble/Graphics/Sprites/ScrollContainer.cs
+++ b/Wobble/Graphics/Sprites/ScrollContainer.cs
@@ -107,6 +107,18 @@ namespace Wobble.Graphics.Sprites
         /// </summary>
         public bool IsMinScrollYEnabled { get; set; } = false;
 
+        
+        public Bindable<bool> InvertedScrollingOverride { get; set; }
+
+        /// <summary>
+        /// Global: null, true or false
+        /// Override: null, true or false
+        /// Local behavior: override if it's set; follows global if not set; false if global is null and local not set;
+        /// </summary>
+        public bool InvertedScrolling => InvertedScrollingOverride?.Value ?? GlobalInvertedScrolling?.Value ?? false;
+
+        public static Bindable<bool> GlobalInvertedScrolling { get; set; }
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>

--- a/Wobble/Graphics/Sprites/ScrollContainer.cs
+++ b/Wobble/Graphics/Sprites/ScrollContainer.cs
@@ -116,9 +116,12 @@ namespace Wobble.Graphics.Sprites
         /// Local behavior: override if it's set; follows global if not set; false if global is null and local not set;
         /// </summary>
         public bool InvertedScrolling => InvertedScrollingOverride?.Value ?? GlobalInvertedScrolling?.Value ?? false;
-
+        
+        /// <summary>
+        /// The global bindable toggle for inverted scrolling
+        /// </summary>
         public static Bindable<bool> GlobalInvertedScrolling { get; set; }
-
+        
         /// <inheritdoc />
         /// <summary>
         /// </summary>

--- a/Wobble/Input/MouseManager.cs
+++ b/Wobble/Input/MouseManager.cs
@@ -17,6 +17,26 @@ namespace Wobble.Input
         public static EnhancedMouseState PreviousState { get; private set; }
 
         /// <summary>
+        ///     Whether the mouse is being scrolled, in either direction
+        /// </summary>
+        public static bool IsScrolling => CurrentState.ScrollWheelValue != PreviousState.ScrollWheelValue;
+
+        /// <summary>
+        ///     Whether the mouse is logically taken to be scrolling up,
+        ///     taking inversion into account.
+        /// </summary>
+        public static bool IsScrollingUp(bool invert = false) => IsScrolling
+                                            && (CurrentState.ScrollWheelValue > PreviousState.ScrollWheelValue)
+                                            ^ invert;
+        /// <summary>
+        ///     Whether the mouse is logically taken to be scrolling down,
+        ///     taking inversion into account.
+        /// </summary>
+        public static bool IsScrollingDown(bool invert = false) => IsScrolling
+                                              && (CurrentState.ScrollWheelValue < PreviousState.ScrollWheelValue)
+                                              ^ invert;
+
+        /// <summary>
         ///     Updates the MouseManager and keeps track of the current and previous mouse states.
         /// </summary>
         internal static void Update()


### PR DESCRIPTION
This PR aims to unify scrolling direction detections with new unified methods and properties in MouseManager. Additionally, it provides a way to invert scrolling. `MouseManager` now has 2 new methods and 1 new property:

+ `IsScrolling`: detects whether the mouse is scrolling, in either direction
+ `IsScrollingDown(bool invert = false)`: Detects whether the mouse is scrolling down. If `invert` is `true`, detects whether the mouse is scrolling up (from logical values)
+ `IsScrollingUp(bool invert = false)`: Same as the previous one but opposite

`ScrollContainer` now has several properties that controls the behavior of scrolling, namely:
+ `GlobalInvertedScrolling`: a bindable toggle that controls default scrolling direction for all ScrollContainers (if null, no inversion)
+ `InvertedScrollingOverride`: a bindable toggle that can override the scrolling direction **specifically** for this very ScrollContainer (if null, follow global)
+ `InvertedScrolling`: the actual property that the `ScrollContainer` uses when calling `MouseManager.IsScrolling<something>()`. This decides, from the previous two properties, how the `ScrollContainer` is finally going to scroll