### PR TITLE
Detect OSX command key

### DIFF
--- a/Wobble/Graphics/UI/Form/Textbox.cs
+++ b/Wobble/Graphics/UI/Form/Textbox.cs
@@ -354,8 +354,7 @@ namespace Wobble.Graphics.UI.Form
 
             // On Linux some characters (like Backspace, plus or minus) get sent here even when CTRL is down, and we
             // don't handle that here.
-            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl)
-                || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            if (KeyboardManager.IsCtrlDown())
                 return;
 
             // Enter is handled in Update() because TextInput only receives the regular Enter and not the NumPad Enter.
@@ -639,7 +638,7 @@ namespace Wobble.Graphics.UI.Form
                 return;
 
             var shift = KeyboardManager.CurrentState.IsKeyDown(Keys.LeftShift) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightShift);
-            var ctrl = KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl);
+            var ctrl = KeyboardManager.IsCtrlDown();
 
             if (KeyboardManager.IsUniqueKeyPress(Keys.Left)
             || (keyHeldFor.ContainsKey(Keys.Left) && keyHeldFor[Keys.Left] > 750
@@ -786,8 +785,7 @@ namespace Wobble.Graphics.UI.Form
         private void HandleCtrlInput()
         {
             // Make sure the textbox is focused and that the control buttons are down before handling anything.
-            if (!Focused || (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl)
-                && !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl)))
+            if (!Focused || !KeyboardManager.IsCtrlDown())
                 return;
 
             // CTRL+A, Select the text.

--- a/Wobble/Input/KeyboardManager.cs
+++ b/Wobble/Input/KeyboardManager.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework.Input;
+using Wobble.Bindables;
 
 namespace Wobble.Input
 {
@@ -46,7 +48,10 @@ namespace Wobble.Input
         ///     Returns if either the control keys are down
         /// </summary>
         /// <returns></returns>
-        public static bool IsCtrlDown() => CurrentState.IsKeyDown(Keys.LeftControl) || CurrentState.IsKeyDown(Keys.RightControl);
+        public static bool IsCtrlDown() =>
+            (CurrentState.IsKeyDown(Keys.LeftControl) || CurrentState.IsKeyDown(Keys.RightControl))
+            || (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                && (CurrentState.IsKeyDown(Keys.LeftWindows) || CurrentState.IsKeyDown(Keys.RightWindows)));
 
         /// <summary>
         ///     Returns if either Alt key is held down


### PR DESCRIPTION
Adds an option to `KeyboardManager`, `OsxUseCommandKey`: any detection for `ctrl` presses will detect `command` key as well.
