### PR TITLE
Avoid exceptions

### DIFF
--- a/Wobble.Extended/HotReload/HotLoader.cs
+++ b/Wobble.Extended/HotReload/HotLoader.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Reflection;
 using Microsoft.Xna.Framework;
 using MonoGame.Extended;
+using Wobble.Logging;
 
 namespace Wobble.Extended.HotReload
 {
@@ -127,7 +128,7 @@ namespace Wobble.Extended.HotReload
         {
             Watcher.EnableRaisingEvents = false;
 
-            Console.WriteLine($"Initializing Compiliation for project: {ProjectName}");
+            Logger.Debug($"Initializing Compilation for project: {ProjectName}", LogType.Runtime);
 
             if (Compiler != null)
             {
@@ -166,7 +167,7 @@ namespace Wobble.Extended.HotReload
             if (p.ExitCode == 0)
             {
                 Compiler = null;
-                Console.WriteLine("Compilation Success!");
+                Logger.Debug("Compilation Success", LogType.Runtime);
                 CompilationFailed = false;
                 Watcher.EnableRaisingEvents = true;
 
@@ -177,7 +178,7 @@ namespace Wobble.Extended.HotReload
             CompilationFailed = true;
             Compiler = null;
             Watcher.EnableRaisingEvents = true;
-            Console.WriteLine(output);
+            Logger.Debug(output, LogType.Runtime);
         }
 
         /// <summary>

--- a/Wobble.Extended/HotReload/Screens/HotLoaderScreenView.cs
+++ b/Wobble.Extended/HotReload/Screens/HotLoaderScreenView.cs
@@ -6,6 +6,7 @@ using Wobble.Extended.HotReload.Screens.UI;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
 using Wobble.Input;
+using Wobble.Logging;
 using Wobble.Screens;
 
 namespace Wobble.Extended.HotReload.Screens
@@ -53,7 +54,7 @@ namespace Wobble.Extended.HotReload.Screens
             var game = (HotLoaderGame) GameBase.Game;
             HotLoader = game.HotLoader;
 
-            Console.WriteLine("Press the Tilde (~) key to open/close the test browser");
+            Logger.Debug("Press the Tilde (~) key to open/close the test browser", LogType.Runtime);
         }
 
         /// <inheritdoc />

--- a/Wobble.Extended/HotReload/Screens/UI/HotLoadingBrowser.cs
+++ b/Wobble.Extended/HotReload/Screens/UI/HotLoadingBrowser.cs
@@ -5,6 +5,7 @@ using Wobble.Assets;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
 using Wobble.Graphics.UI.Buttons;
+using Wobble.Logging;
 using Wobble.Screens;
 using Wobble.Window;
 
@@ -61,7 +62,7 @@ namespace Wobble.Extended.HotReload.Screens.UI
             btn.Clicked += (o, e) =>
             {
                 ScreenView.ChangeScreen(Screens[name]);
-                Console.WriteLine($"Going to screen: {name}");
+                Logger.Important($"Going to screen: {name}", LogType.Runtime);
             };
 
             // ReSharper disable once ObjectCreationAsStatement

--- a/Wobble/Discord/RPC/IO/ManagedNamedPipeClient.cs
+++ b/Wobble/Discord/RPC/IO/ManagedNamedPipeClient.cs
@@ -230,7 +230,15 @@ namespace Wobble.Discord.RPC.IO
 			{
 				if (_stream != null)
 				{
-					try { _stream.Flush(); } catch (Exception) { }
+					try
+					{
+						_stream.Flush();
+					}
+					catch (Exception)
+					{
+						// ignored
+					}
+
 					_stream.Dispose();
 				}
 				else

--- a/Wobble/Discord/RPC/IO/ManagedNamedPipeClient.cs
+++ b/Wobble/Discord/RPC/IO/ManagedNamedPipeClient.cs
@@ -109,27 +109,23 @@ namespace Wobble.Discord.RPC.IO
 
 			try
 			{
-				//Attempt to read the bytes, catching for IO exceptions or dispose exceptions
-				bytes = _stream.EndRead(callback);
+				if (_stream != null)
+					//Attempt to read the bytes, catching for IO exceptions or dispose exceptions
+					bytes = _stream.EndRead(callback);
 			}
 			catch (IOException)
 			{
 				Logger.Warning("Attempted to end reading from a closed pipe");
 				return;
 			}
-			catch(NullReferenceException)
-			{
-				Logger.Warning("Attempted to read from a null pipe");
-				return;
-			}
 			catch(ObjectDisposedException)
 			{
-				Logger.Warning("Attemped to end reading from a disposed pipe");
+				Logger.Warning("Attempted to end reading from a disposed pipe");
 				return;
 			}
 			catch(Exception e)
 			{
-				Logger.Error("A unkown error has occured while reading a pipe: " + e.Message);
+				Logger.Error("An unknown error has occured while reading a pipe: " + e.Message);
 				return;
 			}
 
@@ -223,13 +219,13 @@ namespace Wobble.Discord.RPC.IO
 			//We must have failed the try catch
 			return false;
 		}
-		
+
 		/// <summary>
 		/// Closes the pipe
 		/// </summary>
 		public void Close()
 		{
-			//flush and dispose			
+			//flush and dispose
 			try
 			{
 				if (_stream != null)
@@ -259,6 +255,6 @@ namespace Wobble.Discord.RPC.IO
 		{
 			//Close the stream (disposing of it too)
 			Close();
-		}		
+		}
 	}
 }

--- a/Wobble/Graphics/Drawable.cs
+++ b/Wobble/Graphics/Drawable.cs
@@ -661,7 +661,7 @@ namespace Wobble.Graphics
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine(e);
+                    Logger.Error(e, LogType.Runtime);
                     break;
                 }
             }

--- a/Wobble/Graphics/SpriteBatchOptions.cs
+++ b/Wobble/Graphics/SpriteBatchOptions.cs
@@ -42,20 +42,11 @@ namespace Wobble.Graphics
         public void Begin()
         {
             Matrix? matrix = WindowManager.Scale;
+
             if (DoNotScale)
                 matrix = null;
 
-            // ReSharper disable once ArrangeMethodOrOperatorBody
-            try
-            {
-                GameBase.Game.SpriteBatch.Begin(SortMode, BlendState, SamplerState, DepthStencilState, RasterizerState, Shader?.ShaderEffect, matrix);
-                return;
-            }
-            catch (Exception e)
-            {
-                GameBase.Game.SpriteBatch.End();
-            }
-
+            _ = GameBase.Game.TryEndBatch();
             GameBase.Game.SpriteBatch.Begin(SortMode, BlendState, SamplerState, DepthStencilState, RasterizerState, Shader?.ShaderEffect, matrix);
         }
     }

--- a/Wobble/Graphics/Sprites/RenderTargetContainer.cs
+++ b/Wobble/Graphics/Sprites/RenderTargetContainer.cs
@@ -50,14 +50,7 @@ namespace Wobble.Graphics.Sprites
             });
 
             // Attempt to end the spritebatch
-            try
-            {
-                GameBase.Game.SpriteBatch.End();
-            }
-            catch (Exception e)
-            {
-                // ignored.
-            }
+            _ = GameBase.Game.TryEndBatch();
 
             // Reset the render target.
             GameBase.Game.GraphicsDevice.SetRenderTarget(null);
@@ -74,14 +67,7 @@ namespace Wobble.Graphics.Sprites
             Image = oldImage;
 
             // Attempt to end the spritebatch
-            try
-            {
-                GameBase.Game.SpriteBatch.End();
-            }
-            catch (Exception e)
-            {
-                // ignored.
-            }
+            _ = GameBase.Game.TryEndBatch();
         }
     }
 }

--- a/Wobble/Graphics/Sprites/Sprite.cs
+++ b/Wobble/Graphics/Sprites/Sprite.cs
@@ -142,7 +142,7 @@ namespace Wobble.Graphics.Sprites
                 {
                     DrawToSpriteBatch();
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     GameBase.DefaultSpriteBatchOptions.Begin();
                     GameBase.DefaultSpriteBatchInUse = true;

--- a/Wobble/Graphics/Sprites/Sprite.cs
+++ b/Wobble/Graphics/Sprites/Sprite.cs
@@ -115,14 +115,7 @@ namespace Wobble.Graphics.Sprites
             {
                 // If we actually have new SpriteBatchOptions to use,then
                 // we want to end the previous SpriteBatch.
-                try
-                {
-                    GameBase.Game.SpriteBatch.End();
-                }
-                catch (Exception)
-                {
-                    // ignored
-                }
+                _ = GameBase.Game.TryEndBatch();
 
                 GameBase.DefaultSpriteBatchInUse = false;
 
@@ -134,15 +127,7 @@ namespace Wobble.Graphics.Sprites
             // If the default spritebatch isn't used, we'll want to use it here and draw the sprite.
             else if (!GameBase.DefaultSpriteBatchInUse && !UsePreviousSpriteBatchOptions)
             {
-                try
-                {
-                    // End the previous SpriteBatch.
-                    GameBase.Game.SpriteBatch.End();
-                }
-                catch (Exception)
-                {
-                    // ignored
-                }
+                _ = GameBase.Game.TryEndBatch();
 
                 // Begin the default spriteBatch
                 GameBase.DefaultSpriteBatchOptions.Begin();
@@ -179,7 +164,6 @@ namespace Wobble.Graphics.Sprites
 
             GameBase.Game.SpriteBatch.Draw(Image, RenderRectangle, null, _color, _rotation, Origin, SpriteEffect, 0f);
         }
-
 
         /// <inheritdoc />
         /// <summary>

--- a/Wobble/Graphics/Sprites/SpriteAlphaMaskBlend.cs
+++ b/Wobble/Graphics/Sprites/SpriteAlphaMaskBlend.cs
@@ -23,14 +23,7 @@ namespace Wobble.Graphics.Sprites
             GameBase.Game.GraphicsDevice.SetRenderTarget(RenderTarget);
 
             // Attempt to end the spritebatch
-            try
-            {
-                GameBase.Game.SpriteBatch.End();
-            }
-            catch (Exception e)
-            {
-                // ignored.
-            }
+            _ = GameBase.Game.TryEndBatch();
 
             GameBase.Game.SpriteBatch.Begin(blendState: blend);
             GameBase.Game.SpriteBatch.Draw(srcMask, srcTexture.Bounds, Color.White);

--- a/Wobble/Graphics/Sprites/SpriteTextBitmap.cs
+++ b/Wobble/Graphics/Sprites/SpriteTextBitmap.cs
@@ -144,15 +144,7 @@ namespace Wobble.Graphics.Sprites
             {
                 // If we actually have new SpriteBatchOptions to use,then
                 // we want to end the previous SpriteBatch.
-                try
-                {
-                    GameBase.Game.SpriteBatch.End();
-                }
-                catch (Exception)
-                {
-                    // ignored
-                }
-
+                _ = GameBase.Game.TryEndBatch();
                 GameBase.DefaultSpriteBatchInUse = false;
 
                 // Begin the new SpriteBatch
@@ -163,15 +155,7 @@ namespace Wobble.Graphics.Sprites
             // If the default spritebatch isn't used, we'll want to use it here and draw the sprite.
             else if (!GameBase.DefaultSpriteBatchInUse && !UsePreviousSpriteBatchOptions)
             {
-                try
-                {
-                    // End the previous SpriteBatch.
-                    GameBase.Game.SpriteBatch.End();
-                }
-                catch (Exception)
-                {
-                    // ignored
-                }
+                _ = GameBase.Game.TryEndBatch();
 
                 // Begin the default spriteBatch
                 GameBase.DefaultSpriteBatchOptions.Begin();
@@ -186,7 +170,7 @@ namespace Wobble.Graphics.Sprites
                 {
                     DrawToSpriteBatch();
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     GameBase.DefaultSpriteBatchOptions.Begin();
                     GameBase.DefaultSpriteBatchInUse = true;
@@ -286,19 +270,8 @@ namespace Wobble.Graphics.Sprites
                 GameBase.Game.GraphicsDevice.SetRenderTarget(RenderTarget);
                 GameBase.Game.GraphicsDevice.Clear(Color.Transparent);
 
-                try
-                {
-                    GameBase.Game.SpriteBatch.End();
-                }
-                catch (Exception e)
-                {
-                    // ignored
-
-                }
-                finally
-                {
-                    GameBase.Game.SpriteBatch.Begin(SpriteSortMode.Immediate, BlendState.Opaque);
-                }
+                _ = GameBase.Game.TryEndBatch();
+                GameBase.Game.SpriteBatch.Begin(SpriteSortMode.Immediate, BlendState.Opaque);
 
                 GameBase.Game.SpriteBatch.DrawString(Font, DisplayedText, new Vector2(0, 0), Color.White, Rotation,
                     Vector2.Zero, new Vector2((float)FontSize / Font.LineHeight, (float)FontSize / Font.LineHeight),

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlusLine.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlusLine.cs
@@ -198,15 +198,7 @@ namespace Wobble.Graphics.Sprites.Text
             if (IsDisposed)
                 return;
 
-            try
-            {
-                GameBase.Game.SpriteBatch.End();
-            }
-            catch (Exception)
-            {
-                // ignored
-            }
-
+            _ = GameBase.Game.TryEndBatch();
             var (width, height) = _raw.AbsoluteSize;
             var pixelWidth = (int) Math.Ceiling(width);
             var pixelHeight = (int) Math.Ceiling(height);
@@ -228,7 +220,7 @@ namespace Wobble.Graphics.Sprites.Text
             GameBase.Game.GraphicsDevice.SetRenderTarget(RenderTarget);
             GameBase.Game.GraphicsDevice.Clear(Color.TransparentBlack);
             _raw.Draw(gameTime);
-            GameBase.Game.SpriteBatch.End();
+            _ = GameBase.Game.TryEndBatch();
 
             GameBase.Game.GraphicsDevice.SetRenderTarget(null);
 

--- a/Wobble/IO/ResourceStore.cs
+++ b/Wobble/IO/ResourceStore.cs
@@ -144,8 +144,9 @@ namespace Wobble.IO
                         if (result != null)
                             return result;
                     }
-                    catch
+                    catch (Exception)
                     {
+                        // ignored
                     }
                 }
 

--- a/Wobble/IO/ResourceStore.cs
+++ b/Wobble/IO/ResourceStore.cs
@@ -110,17 +110,21 @@ namespace Wobble.IO
         /// <returns>The object.</returns>
         public virtual T Get(string name)
         {
+            if (name is null)
+                return default;
+
             var filenames = GetFilenames(name);
 
             // Cache miss - get the resource
             lock (stores)
                 foreach (var store in stores)
-                foreach (var f in filenames)
-                {
-                    var result = store.Get(f);
-                    if (result != null)
-                        return result;
-                }
+                    foreach (var f in filenames)
+                    {
+                        var result = store.Get(f);
+
+                        if (result != null)
+                            return result;
+                    }
 
             return default;
         }

--- a/Wobble/Logging/LogLevel.cs
+++ b/Wobble/Logging/LogLevel.cs
@@ -7,8 +7,8 @@ namespace Wobble.Logging
     public enum LogLevel
     {
         Debug,
-        Warning,
         Important,
-        Error
+        Warning,
+        Error,
     }
 }

--- a/Wobble/Logging/Logger.cs
+++ b/Wobble/Logging/Logger.cs
@@ -12,11 +12,8 @@ namespace Wobble.Logging
         static Logger() =>
             MinimumLogLevel = Enum.TryParse(Environment.GetEnvironmentVariable("QUAVER_LOGLEVEL"), out LogLevel level)
                 ? level
-#if PUBLIC
-                : LogLevel.Important;
-#else
                 : LogLevel.Debug;
-#endif
+
         /// <summary>
         ///     Dictates whether to display log messages (if in debug)
         /// </summary>

--- a/Wobble/Logging/Logger.cs
+++ b/Wobble/Logging/Logger.cs
@@ -9,15 +9,30 @@ namespace Wobble.Logging
 {
     public static class Logger
     {
+        static Logger() =>
+            MinimumLogLevel = Enum.TryParse(Environment.GetEnvironmentVariable("QUAVER_LOGLEVEL"), out LogLevel level)
+                ? level
+#if PUBLIC
+                : LogLevel.Important;
+#else
+                : LogLevel.Debug;
+#endif
         /// <summary>
-        ///     Dictates whether or not to display log messages (if in debug)
+        ///     Dictates whether to display log messages (if in debug)
         /// </summary>
         public static bool DisplayMessages { get; set; } = true;
 
         /// <summary>
         ///     The folder which contains all the logs.
         /// </summary>
-        public static string LogsFolder => $"{AppDomain.CurrentDomain.BaseDirectory}/Logs";
+        public static string LogsFolder => Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Logs");
+
+        /// <summary>
+        ///     The minimum log level required to log messages.
+        /// </summary>
+        // Just to keep things convenient, we're exposing this setter in case it ever is needed.
+        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
+        public static LogLevel MinimumLogLevel { get; set; }
 
         /// <summary>
         ///     Gets the path of an individual LogType.
@@ -43,13 +58,12 @@ namespace Wobble.Logging
 
             foreach (LogType type in Enum.GetValues(typeof(LogType)))
             {
-                if (File.Exists(GetLogPath(type)))
-                    File.Delete(GetLogPath(type));
+                var path = GetLogPath(type);
 
-                using (var f = File.Create(GetLogPath(type)))
-                {
-                }
+                if (File.Exists(path))
+                    File.Delete(path);
 
+                File.Create(path).Dispose();
                 Debug($"OS: {System.Runtime.InteropServices.RuntimeInformation.OSDescription}", type);
             }
         }
@@ -99,8 +113,12 @@ namespace Wobble.Logging
         /// </summary>
         public static void Log(string m, LogLevel level, LogType type, bool writeToFile = true)
         {
+            if ((int)level < (int)MinimumLogLevel)
+                return;
+
             // Get a stringified version of the log level, and also set the color.
             var logLevelStr = "";
+
             switch (level)
             {
                 case LogLevel.Debug:

--- a/Wobble/Scheduling/TaskHandler.cs
+++ b/Wobble/Scheduling/TaskHandler.cs
@@ -98,7 +98,7 @@ namespace Wobble.Scheduling
                     OnCompleted?.Invoke(typeof(TaskHandler<T, TResult>),
                         new TaskCompleteEventArgs<T, TResult>(input, result));
                 }
-                catch (OperationCanceledException e)
+                catch (OperationCanceledException)
                 {
                     OnSourceCancelled(input);
                 }

--- a/Wobble/Wobble.csproj
+++ b/Wobble/Wobble.csproj
@@ -1,13 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>


### PR DESCRIPTION
See [the main PR](https://github.com/Quaver/Quaver/pull/4112) for details.

Avoids polluting the runtime with exception-throwing, preventing where applicable.

Reflection is used to get `SpriteBatch` booleans despite having access to source code just in case we ever choose to migrate to using the NuGet package.
