### PR TITLE
Use Deferred everywhere possible

### DIFF
--- a/Wobble/GameBase.cs
+++ b/Wobble/GameBase.cs
@@ -32,7 +32,7 @@ namespace Wobble
         /// </summary>
         public static SpriteBatchOptions DefaultSpriteBatchOptions { get; set; } = new SpriteBatchOptions()
         {
-            SortMode = SpriteSortMode.Immediate,
+            SortMode = SpriteSortMode.Deferred,
             BlendState = BlendState.NonPremultiplied,
         };
 

--- a/Wobble/Graphics/ImGUI/ImGuiRenderer.cs
+++ b/Wobble/Graphics/ImGUI/ImGuiRenderer.cs
@@ -365,6 +365,9 @@ namespace Wobble.Graphics.ImGUI
             var lastRasterizerState = GraphicsDevice.RasterizerState;
             var lastDepthStencilState = GraphicsDevice.DepthStencilState;
 
+            // We are submitting vertex and index buffers without using SpriteBatch.
+            // We need to end the batch so we are drawing on top of those that are not flushed
+            GameBase.Game.TryEndBatch();
             GraphicsDevice.BlendFactor = Color.White;
             GraphicsDevice.BlendState = BlendState.NonPremultiplied;
             GraphicsDevice.RasterizerState = RasterizerState;

--- a/Wobble/Graphics/SpriteBatchOptions.cs
+++ b/Wobble/Graphics/SpriteBatchOptions.cs
@@ -12,7 +12,7 @@ namespace Wobble.Graphics
     /// </summary>
     public class SpriteBatchOptions
     {
-        public SpriteSortMode SortMode { get; set; } = SpriteSortMode.Immediate;
+        public SpriteSortMode SortMode { get; set; } = SpriteSortMode.Deferred;
         public BlendState BlendState { get; set; } = BlendState.NonPremultiplied;
         public SamplerState SamplerState { get; set; } = SamplerState.LinearClamp;
         public DepthStencilState DepthStencilState { get; set; }

--- a/Wobble/Graphics/Sprites/ScrollContainer.cs
+++ b/Wobble/Graphics/Sprites/ScrollContainer.cs
@@ -132,7 +132,7 @@ namespace Wobble.Graphics.Sprites
             // Create the SpriteBatchOptions with scissor rect enabled.
             SpriteBatchOptions = new SpriteBatchOptions
             {
-                SortMode = SpriteSortMode.Immediate,
+                SortMode = SpriteSortMode.Deferred,
                 BlendState = BlendState.NonPremultiplied,
                 RasterizerState = new RasterizerState
                 {

--- a/Wobble/Graphics/Sprites/SpriteTextBitmap.cs
+++ b/Wobble/Graphics/Sprites/SpriteTextBitmap.cs
@@ -271,7 +271,7 @@ namespace Wobble.Graphics.Sprites
                 GameBase.Game.GraphicsDevice.Clear(Color.Transparent);
 
                 _ = GameBase.Game.TryEndBatch();
-                GameBase.Game.SpriteBatch.Begin(SpriteSortMode.Immediate, BlendState.Opaque);
+                GameBase.Game.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.Opaque);
 
                 GameBase.Game.SpriteBatch.DrawString(Font, DisplayedText, new Vector2(0, 0), Color.White, Rotation,
                     Vector2.Zero, new Vector2((float)FontSize / Font.LineHeight, (float)FontSize / Font.LineHeight),


### PR DESCRIPTION
Use `Deferred` Sort mode wherever possible:
* Default value of `SortMode` in `SpriteBatchOptions`
* Value set in `GameBase.DefaultSpriteBatchOptions`
* Scroll Containers
* `SpriteTextBitmap`

Adds an `TryEndBatch` call before ImGui rendering because it submits draw calls that bypass the SpriteBatch. It should give the same behavior as before.