### PR TITLE
Add basic rotation & scaling & pivoting

### DIFF
--- a/Wobble.Tests/Screens/Selection/SelectionScreen.cs
+++ b/Wobble.Tests/Screens/Selection/SelectionScreen.cs
@@ -17,6 +17,8 @@ namespace Wobble.Tests.Screens.Selection
         public Dictionary<ScreenType, string> TestCasesScreens { get; } = new Dictionary<ScreenType, string>
         {
             {ScreenType.DrawingSprites, "Drawing Sprites"},
+            {ScreenType.Rotation, "Rotation"},
+            {ScreenType.DrawableScaling, "Drawable Scaling"},
             {ScreenType.EasingAnimations, "Easing Animations"},
             {ScreenType.Audio, "Audio"},
             {ScreenType.Discord, "Discord Rich Pr."},
@@ -48,6 +50,8 @@ namespace Wobble.Tests.Screens.Selection
     public enum ScreenType
     {
         DrawingSprites,
+        Rotation,
+        DrawableScaling,
         EasingAnimations,
         Audio,
         Discord,

--- a/Wobble.Tests/Screens/Selection/SelectionScreenView.cs
+++ b/Wobble.Tests/Screens/Selection/SelectionScreenView.cs
@@ -15,11 +15,13 @@ using Wobble.Tests.Screens.Tests.BitmapFont;
 using Wobble.Tests.Screens.Tests.BlurContainer;
 using Wobble.Tests.Screens.Tests.BlurredBgImage;
 using Wobble.Tests.Screens.Tests.Discord;
+using Wobble.Tests.Screens.Tests.DrawableScaling;
 using Wobble.Tests.Screens.Tests.DrawingSprites;
 using Wobble.Tests.Screens.Tests.EasingAnimations;
 using Wobble.Tests.Screens.Tests.Joystick;
 using Wobble.Tests.Screens.Tests.Imgui;
 using Wobble.Tests.Screens.Tests.Primitives;
+using Wobble.Tests.Screens.Tests.Rotation;
 using Wobble.Tests.Screens.Tests.Scaling;
 using Wobble.Tests.Screens.Tests.ScheduledUpdates;
 using Wobble.Tests.Screens.Tests.Scrolling;
@@ -102,6 +104,12 @@ namespace Wobble.Tests.Screens.Selection
                 {
                     case ScreenType.DrawingSprites:
                         button.Clicked += (o, e) => ScreenManager.ChangeScreen(new TestDrawingSpritesScreen());
+                        break;
+                    case ScreenType.Rotation:
+                        button.Clicked += (o, e) => ScreenManager.ChangeScreen(new TestRotationScreen());
+                        break;
+                    case ScreenType.DrawableScaling:
+                        button.Clicked += (o, e) => ScreenManager.ChangeScreen(new TestDrawableScalingScreen());
                         break;
                     case ScreenType.EasingAnimations:
                         button.Clicked += (o, e) => ScreenManager.ChangeScreen(new TestEasingAnimationsScreen());

--- a/Wobble.Tests/Screens/Tests/DrawableScaling/TestDrawableScalingScreen.cs
+++ b/Wobble.Tests/Screens/Tests/DrawableScaling/TestDrawableScalingScreen.cs
@@ -1,0 +1,17 @@
+using Wobble.Screens;
+using Wobble.Tests.Screens.Tests.Rotation;
+
+namespace Wobble.Tests.Screens.Tests.DrawableScaling
+{
+    public class TestDrawableScalingScreen : Screen
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public sealed override ScreenView View { get; protected set; }
+
+        /// <summary>
+        /// </summary>
+        public TestDrawableScalingScreen() => View = new TestDrawableScalingScreenView(this);
+    }
+}

--- a/Wobble.Tests/Screens/Tests/DrawableScaling/TestDrawableScalingScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/DrawableScaling/TestDrawableScalingScreenView.cs
@@ -1,0 +1,176 @@
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+using Wobble.Input;
+using Wobble.Screens;
+
+namespace Wobble.Tests.Screens.Tests.DrawableScaling
+{
+    public class TestDrawableScalingScreenView : ScreenView
+    {
+        /// <summary>
+        ///     Green box sprite.
+        /// </summary>
+        public Sprite GreenBox { get; }
+
+        public Sprite TopLeft { get; }
+
+        public Sprite Mid { get; }
+
+        public Sprite BottomRight { get; }
+
+        public SpriteText SpriteText { get; }
+
+        /// <summary>
+        ///     The background color for the scene.
+        /// </summary>
+        private Color BackgroundColor { get; set; } = Color.CornflowerBlue;
+
+        private Vector2 _scale = Vector2.One;
+        private bool _rotating;
+
+        private SpriteText DebugText { get; }
+
+        public Vector2 Scale
+        {
+            get => _scale;
+            private set
+            {
+                _scale = value;
+                GreenBox.Scale = value;
+                // Mid.Scale = value;
+                // BottomRight.Scale = value;
+                DebugText.ScheduleUpdate(() => DebugText.Text = $"Scale: {value}");
+            }
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="screen"></param>
+        public TestDrawableScalingScreenView(Screen screen) : base(screen)
+        {
+            #region GREEN_BOX
+
+            GreenBox = new Sprite()
+            {
+                Parent = Container,
+                Size = new ScalableVector2(200, 400),
+                Tint = Color.Green,
+                Position = new ScalableVector2(0, 0),
+                Alignment = Alignment.MidCenter,
+                Pivot = Vector2.One
+            };
+
+            TopLeft = new Sprite()
+            {
+                Parent = GreenBox,
+                Size = new ScalableVector2(100, 200),
+                Tint = Color.Blue,
+                Position = new ScalableVector2(0, 0),
+                Alignment = Alignment.TopLeft,
+                // Pivot = new Vector2(1, 1)
+            };
+
+            BottomRight = new Sprite()
+            {
+                Parent = GreenBox,
+                Size = new ScalableVector2(100, 200),
+                Tint = Color.YellowGreen,
+                Position = new ScalableVector2(0, 0),
+                Alignment = Alignment.BotRight,
+                Pivot = new Vector2(1, 1)
+            };
+
+            Mid = new Sprite()
+            {
+                Parent = GreenBox,
+                Size = new ScalableVector2(50, 50),
+                Tint = Color.Red,
+                Position = new ScalableVector2(0, 0),
+                Alignment = Alignment.MidCenter,
+            };
+
+            SpriteText = new SpriteText("exo2-bold", "ABC", 20)
+            {
+                Parent = BottomRight,
+                Size = new ScalableVector2(50, 50),
+                Alignment = Alignment.MidCenter
+            };
+
+            GreenBox.AddBorder(Color.White, 2);
+
+            TopLeft.AddBorder(Color.Red, 2);
+
+            Mid.AddBorder(Color.LightYellow, 2);
+
+            BottomRight.AddBorder(Color.Purple, 2);
+
+            #endregion
+
+            DebugText = new SpriteText("exo2-bold", "Hello, World!", 18)
+            {
+                Parent = Container,
+                Alignment = Alignment.TopRight
+            };
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            Container?.Update(gameTime);
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Up))
+                Scale += new Vector2(0, 0.25f);
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Right))
+                Scale += new Vector2(0.25f, 0);
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Down))
+                Scale -= new Vector2(0, 0.25f);
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Left))
+                Scale -= new Vector2(0.25f, 0);
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.R))
+                _rotating = !_rotating;
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.OemCloseBrackets))
+                GreenBox.Rotation += MathF.PI / 2;
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.OemOpenBrackets))
+                GreenBox.Rotation -= MathF.PI / 2;
+
+            if (_rotating)
+                GreenBox.Rotation += 0.0001f;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime)
+        {
+            GameBase.Game.GraphicsDevice.Clear(BackgroundColor);
+            Container?.Draw(gameTime);
+
+            try
+            {
+                GameBase.Game.SpriteBatch.End();
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy() => Container?.Destroy();
+    }
+}

--- a/Wobble.Tests/Screens/Tests/DrawableScaling/TestDrawableScalingScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/DrawableScaling/TestDrawableScalingScreenView.cs
@@ -159,13 +159,7 @@ namespace Wobble.Tests.Screens.Tests.DrawableScaling
             GameBase.Game.GraphicsDevice.Clear(BackgroundColor);
             Container?.Draw(gameTime);
 
-            try
-            {
-                GameBase.Game.SpriteBatch.End();
-            }
-            catch (Exception)
-            {
-            }
+            GameBase.Game.TryEndBatch();
         }
 
         /// <inheritdoc />

--- a/Wobble.Tests/Screens/Tests/Rotation/TestRotationScreen.cs
+++ b/Wobble.Tests/Screens/Tests/Rotation/TestRotationScreen.cs
@@ -1,0 +1,16 @@
+using Wobble.Screens;
+
+namespace Wobble.Tests.Screens.Tests.Rotation
+{
+    public class TestRotationScreen : Screen
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public sealed override ScreenView View { get; protected set; }
+
+        /// <summary>
+        /// </summary>
+        public TestRotationScreen() => View = new TestRotationScreenView(this);
+    }
+}

--- a/Wobble.Tests/Screens/Tests/Rotation/TestRotationScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/Rotation/TestRotationScreenView.cs
@@ -151,13 +151,7 @@ namespace Wobble.Tests.Screens.Tests.Rotation
             GameBase.Game.GraphicsDevice.Clear(BackgroundColor);
             Container?.Draw(gameTime);
 
-            try
-            {
-                GameBase.Game.SpriteBatch.End();
-            }
-            catch (Exception)
-            {
-            }
+            GameBase.Game.TryEndBatch();
         }
 
         /// <inheritdoc />

--- a/Wobble.Tests/Screens/Tests/Rotation/TestRotationScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/Rotation/TestRotationScreenView.cs
@@ -1,0 +1,168 @@
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using MonoGame.Extended.Timers;
+using Wobble.Assets;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+using Wobble.Input;
+using Wobble.Screens;
+
+namespace Wobble.Tests.Screens.Tests.Rotation
+{
+    public class TestRotationScreenView : ScreenView
+    {
+        /// <summary>
+        ///     Green box sprite.
+        /// </summary>
+        public Sprite GreenBox { get; }
+
+        public Sprite BlueBox { get; }
+
+        public Sprite Shaft { get; }
+
+        public Sprite CollisionBox { get; }
+
+        public Sprite SpriteFixZRotation { get; }
+
+        /// <summary>
+        ///     The background color for the scene.
+        /// </summary>
+        private Color BackgroundColor { get; set; } = Color.CornflowerBlue;
+
+        private bool _rotating = true;
+
+        private SpriteText DebugText { get; }
+
+        private float _increment = 0.0005f;
+
+        private readonly ContinuousClock _clock = new ContinuousClock(TimeSpan.FromMilliseconds(16));
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="screen"></param>
+        public TestRotationScreenView(Screen screen) : base(screen)
+        {
+            #region GREEN_BOX
+
+            GreenBox = new Sprite
+            {
+                Image = WobbleAssets.Wallpaper,
+                Parent = Container,
+                Size = new ScalableVector2(50, 100),
+                Tint = Color.Green,
+                Position = new ScalableVector2(200, 200),
+                Alignment = Alignment.MidCenter,
+                // Pivot = Vector2.Zero
+            };
+
+            BlueBox = new Sprite()
+            {
+                Parent = GreenBox,
+                Size = new ScalableVector2(100, 25),
+                Tint = Color.Blue,
+                Position = new ScalableVector2(50, 100),
+                Alignment = Alignment.TopLeft,
+                Pivot = new Vector2(1, 1)
+            };
+
+            Shaft = new Sprite()
+            {
+                Parent = GreenBox,
+                Size = new ScalableVector2(100 / MathF.Cos(25f / 100), 5),
+                Tint = Color.Blue,
+                Position = new ScalableVector2(50, 100),
+                Alignment = Alignment.TopLeft,
+                Rotation = MathF.Atan(25f / 100),
+                Pivot = Vector2.Zero
+            };
+
+            CollisionBox = new Sprite
+            {
+                Parent = Container,
+                Tint = new Color(255, 255, 255, 100),
+                Alignment = Alignment.TopLeft,
+                Size = new ScalableVector2(564, 880),
+                Position = new ScalableVector2(32, -56),
+            };
+
+            // The sprite should have a visually constant rotation
+            SpriteFixZRotation = new Sprite
+            {
+                Parent = GreenBox,
+                Image = WobbleAssets.Wallpaper,
+                Alignment = Alignment.MidCenter,
+                Size = new ScalableVector2(200, 50),
+                Position = new ScalableVector2(200, 100),
+                IndependentRotation = true,
+                Rotation = MathHelper.ToRadians(30)
+            };
+
+            GreenBox.AddBorder(Color.White, 2);
+
+            BlueBox.AddBorder(Color.Red, 2);
+
+            CollisionBox.AddBorder(Color.Red, 2);
+
+            #endregion
+
+            DebugText = new SpriteText("exo2-bold", "Hello, World!", 18)
+            {
+                Parent = Container, Alignment = Alignment.TopRight
+            };
+            _clock.Tick += (sender, args) =>
+                DebugText.ScheduleUpdate(() => DebugText.Text = $"{GreenBox.Rotation:0.00} {_increment}/tick");
+            _clock.Start();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            _clock.Update(gameTime);
+            Container?.Update(gameTime);
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.R))
+                _rotating = !_rotating;
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.OemCloseBrackets))
+                _increment *= 2;
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.OemOpenBrackets))
+                _increment /= 2;
+
+            if (_rotating)
+            {
+                GreenBox.Rotation += _increment;
+                BlueBox.Rotation += _increment;
+                CollisionBox.Rotation += _increment;
+            }
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime)
+        {
+            GameBase.Game.GraphicsDevice.Clear(BackgroundColor);
+            Container?.Draw(gameTime);
+
+            try
+            {
+                GameBase.Game.SpriteBatch.End();
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy() => Container?.Destroy();
+    }
+}

--- a/Wobble/Graphics/Drawable.cs
+++ b/Wobble/Graphics/Drawable.cs
@@ -525,7 +525,7 @@ namespace Wobble.Graphics
             if (!Visible)
                 return;
 
-            if (!RectangleF.Intersects(ScreenRectangle, new RectangleF(0, 0, WindowManager.Width, WindowManager.Height)) && !DrawIfOffScreen)
+            if (!RectangleF.Intersects(ScreenMinimumBoundingRectangle, new RectangleF(0, 0, WindowManager.Width, WindowManager.Height)) && !DrawIfOffScreen)
                 return;
 
             // Draw the children and set their order.

--- a/Wobble/Graphics/Drawable.cs
+++ b/Wobble/Graphics/Drawable.cs
@@ -172,9 +172,8 @@ namespace Wobble.Graphics
                 var height = MathHelper.Clamp(value.Y.Value, 0, int.MaxValue);
 
                 _size = new ScalableVector2(width, height, value.X.Scale, value.Y.Scale);
-                Pivot = Pivot;
-                SizeChanged?.Invoke(this, value);
                 RecalculateRectangles();
+                SizeChanged?.Invoke(this, value);
             }
         }
 

--- a/Wobble/Graphics/Drawable.cs
+++ b/Wobble/Graphics/Drawable.cs
@@ -82,6 +82,68 @@ namespace Wobble.Graphics
         public RectangleF RelativeRectangle { get; private set; }
 
         /// <summary>
+        ///     If outside this region, this will not be drawed.
+        /// </summary>
+        private RectangleF DrawRectangleMask { get; set; } =
+            new RectangleF(0, 0, WindowManager.Width, WindowManager.Height);
+
+        /// <summary>
+        ///     Clipping region for children. Useful to RenderTargets
+        /// </summary>
+        protected virtual RectangleF ChildDrawRectangleMask { get; set; }
+
+        /// <summary>
+        ///     The bounding box of the drawable relative to the entire screen.
+        /// </summary>
+        public RectangleF ScreenMinimumBoundingRectangle { get; private set; } = new RectangleF();
+
+        /// <summary>
+        ///     The total width of the drawable, considering the width scale
+        /// </summary>
+        private float RelativeWidth =>
+            _size.X.Value + (Parent?.ScreenRectangle.Width ?? WindowManager.VirtualScreen.X) * _size.X.Scale;
+
+        /// <summary>
+        ///     The total height of the drawable, considering the height scale
+        /// </summary>
+        private float RelativeHeight =>
+            _size.Y.Value + (Parent?.ScreenRectangle.Height ?? WindowManager.VirtualScreen.Y) * _size.Y.Scale;
+
+
+        private RectangleF _alignedRelativeRectangle;
+
+        /// <summary>
+        ///     The rectangle relative to the drawable's parent.
+        /// </summary>
+        public RectangleF AlignedRelativeRectangle
+        {
+            get => _alignedRelativeRectangle;
+            private set
+            {
+                _alignedRelativeRectangle = value;
+                var size = new Vector2(value.Width, value.Height);
+                var position = new Vector2(value.X, value.Y);
+                var offsetFactor = Vector2.One - _scale;
+
+                // scaledPos = value.Position + Pivot * (Vector2.One - Scale) * value.Size,
+                // scaledSize = value.Size * Scale
+                Vector2.Multiply(ref _pivot, ref offsetFactor, out var intermediate);
+                Vector2.Multiply(ref intermediate, ref size, out var intermediate2);
+                Vector2.Add(ref position, ref intermediate2, out var scaledPos);
+                Vector2.Multiply(ref size, ref _scale, out var scaledSize);
+                
+                // Update _scaledAlignedRelativeRectangle
+                // So that the rectangle is scaled with its position adjusted according to the pivot and scale
+                _scaledAlignedRelativeRectangle = new RectangleF(scaledPos.X, scaledPos.Y,
+                    scaledSize.X, scaledSize.Y);
+            }
+        }
+
+        /// <summary>
+        ///     The rectangle relative to the drawable's parent.
+        /// </summary>
+        private RectangleF _scaledAlignedRelativeRectangle;
+        /// <summary>
         ///     The position of the drawable
         /// </summary>
         private ScalableVector2 _position = new ScalableVector2(0, 0);
@@ -95,6 +157,8 @@ namespace Wobble.Graphics
             }
         }
 
+
+        public event EventHandler<ScalableVector2> SizeChanged;
         /// <summary>
         ///     The size of the drawable.
         /// </summary>
@@ -108,6 +172,8 @@ namespace Wobble.Graphics
                 var height = MathHelper.Clamp(value.Y.Value, 0, int.MaxValue);
 
                 _size = new ScalableVector2(width, height, value.X.Scale, value.Y.Scale);
+                Pivot = Pivot;
+                SizeChanged?.Invoke(this, value);
                 RecalculateRectangles();
             }
         }
@@ -208,6 +274,19 @@ namespace Wobble.Graphics
             }
         }
 
+        private Vector2 _scale = Vector2.One;
+
+        public Vector2 Scale
+        {
+            get => _scale;
+            set
+            {
+                _scale = value;
+                RecalculateRectangles();
+            }
+        }
+
+        public Vector2 AbsoluteScale { get; private set; }
         /// <summary>
         ///     The alignment of the object.
         /// </summary>
@@ -261,6 +340,49 @@ namespace Wobble.Graphics
         ///     The absolute position of the object relative to the screen.
         /// </summary>
         public Vector2 AbsolutePosition => new Vector2(ScreenRectangle.X, ScreenRectangle.Y);
+
+        private Vector2 _pivot = new Vector2(0.5f, 0.5f);
+
+        /// <summary>
+        ///     The pivot about which the rotation will be performed.
+        ///     (0, 0) corresponds to the top-left corner, (1, 1) bottom right.
+        /// </summary>
+        public Vector2 Pivot
+        {
+            get => _pivot;
+            set
+            {
+                _pivot = value;
+                RecalculateRectangles();
+            }
+        }
+
+        /// <summary>
+        ///     Angle of the sprite with it's origin in the centre. (TEMPORARILY NOT USED YET)
+        /// </summary>
+        private float _rotation;
+        public float Rotation
+        {
+            get => _rotation;
+            set
+            {
+                _rotation = value;
+                RecalculateRectangles();
+            }
+        }
+
+        public float AbsoluteRotation { get; private set; }
+
+        /// <summary>
+        ///     Applying this to <see cref="AlignedRelativeRectangle"/> gives the screen space position
+        /// </summary>
+        private Matrix2D _childPositionTransform = Matrix2D.Identity;
+
+        /// <summary>
+        ///     A transform that rotates the relative coordinates about the pivot
+        ///     Applying this to <see cref="AlignedRelativeRectangle"/> gives the relative coordinate after rotation.
+        /// </summary>
+        private Matrix2D _childRelativeTransform = Matrix2D.Identity;
 
         /// <summary>
         ///     Determines if the object is going to get drawn.
@@ -343,6 +465,25 @@ namespace Wobble.Graphics
         /// </summary>
         private List<Action> ScheduledUpdates { get; } = new List<Action>();
 
+        protected virtual void RecalculateTransformMatrix()
+        {
+            var relativeOrigin = Pivot * new Vector2(RelativeWidth, RelativeHeight);
+
+            // Move so the origin is at RelativeOrigin, rotate, then move back
+            var shiftToOrigin = Matrix2D.CreateTranslation(-relativeOrigin);
+            var scalingMatrix = Matrix2D.CreateScale(Scale);
+            var rotationMatrix = Matrix2D.CreateRotationZ(Rotation);
+            var originBack = Matrix2D.CreateTranslation(relativeOrigin * Scale);
+            var thisTranslation = Matrix2D.CreateTranslation(_scaledAlignedRelativeRectangle.Position);
+            var parentTransform = Parent?._childPositionTransform ?? Matrix2D.Identity;
+            Matrix2D.Multiply(ref shiftToOrigin, ref scalingMatrix, out var intermediate1);
+            Matrix2D.Multiply(ref rotationMatrix, ref originBack, out var intermediate2);
+            Matrix2D.Multiply(ref thisTranslation, ref parentTransform, out var outerTransform);
+
+            Matrix2D.Multiply(ref intermediate1, ref intermediate2, out _childRelativeTransform);
+            // Finally, apply our parent's transformation
+            Matrix2D.Multiply(ref _childRelativeTransform, ref outerTransform, out _childPositionTransform);
+        }
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -457,47 +598,77 @@ namespace Wobble.Graphics
         /// </summary>
         public virtual void Dispose() => IsDisposed = true;
 
+
+        public void RecalculateDrawMask()
+        {
+            DrawRectangleMask = Parent?.ChildDrawRectangleMask
+                                ?? new RectangleF(0, 0, WindowManager.Width, WindowManager.Height);
+            ChildDrawRectangleMask = DrawRectangleMask;
+        }
+
         /// <summary>
         ///     Recalculates the local and global rectangles of the object. Makes sure that the position
         ///     and sizes are relative to the parent if the drawable has one.
         /// </summary>
         protected void RecalculateRectangles()
         {
+            // Update AbsoluteRotation
+            AbsoluteRotation = (Parent?.AbsoluteRotation ?? 0) + Rotation;
+            AbsoluteScale = (Parent?.AbsoluteScale ?? Vector2.One) * Scale;
+        
+            RecalculateDrawMask();
+
             // Make it relative to the parent.
+            var width = RelativeWidth;
+            var height = RelativeHeight;
+            var x = Position.X.Value;
+            var y = Position.Y.Value;
+
+            RelativeRectangle = new RectangleF(x, y, width, height);
             if (Parent != null)
             {
-                var width = Size.X.Value + Parent.ScreenRectangle.Width * WidthScale;
-                var height = Size.Y.Value + Parent.ScreenRectangle.Height * HeightScale;
-                var x = Position.X.Value;
-                var y = Position.Y.Value;
-
-                RelativeRectangle = new RectangleF(x, y, width, height);
-                ScreenRectangle = GraphicsHelper.AlignRect(Alignment, RelativeRectangle, Parent.ScreenRectangle);
+                AlignedRelativeRectangle =
+                    GraphicsHelper.AlignRect(Alignment, RelativeRectangle, Parent.RelativeRectangle, true);
+                ScreenRectangle = GraphicsHelper.Transform(_scaledAlignedRelativeRectangle,
+                    Parent._childPositionTransform, Parent.AbsoluteScale);
             }
             // Make it relative to the screen size.
             else
             {
-                var width = Size.X.Value + WindowManager.VirtualScreen.X * WidthScale;
-                var height = Size.Y.Value + WindowManager.VirtualScreen.Y * HeightScale;
-                var x = Position.X.Value;
-                var y = Position.Y.Value;
-
-                RelativeRectangle = new RectangleF(x, y, width, height);
-                ScreenRectangle = GraphicsHelper.AlignRect(Alignment, RelativeRectangle, WindowManager.Rectangle);
+                AlignedRelativeRectangle =
+                    GraphicsHelper.AlignRect(Alignment, RelativeRectangle, WindowManager.Rectangle, true);
+                ScreenRectangle = GraphicsHelper.Offset(_scaledAlignedRelativeRectangle, WindowManager.Rectangle);
             }
+
+            // Update the matrix, now that we have AlignedRelativeRectangle calculated
+            // Note that this calculation of AlignedRelativeRectangle and ScreenRectangle relies on the parent's
+            // transform, and the parent's matrices are calculated before RecalculateRectangles() is called, had there
+            // been an update to the parent.
+            RecalculateTransformMatrix();
+
+            var relativeBoundingRectangle =
+                GraphicsHelper.MinimumBoundingRectangle(ScreenRectangle, AbsoluteRotation, true);
 
             // Recalculate the border points.
             if (Border != null)
             {
                 Border.Points = new List<Vector2>()
                 {
-                    new Vector2(0, 0),
-                    new Vector2(Width, 0),
-                    new Vector2(Width, Height),
-                    new Vector2(0, Height),
-                    new Vector2(0, 0)
+                    new Vector2(relativeBoundingRectangle.Left, relativeBoundingRectangle.Top),
+                    new Vector2(relativeBoundingRectangle.Right, relativeBoundingRectangle.Top),
+                    new Vector2(relativeBoundingRectangle.Right, relativeBoundingRectangle.Bottom),
+                    new Vector2(relativeBoundingRectangle.Left, relativeBoundingRectangle.Bottom),
+                    new Vector2(relativeBoundingRectangle.Left, relativeBoundingRectangle.Top)
                 };
             }
+
+            // (0, 0) * ChildPositionTransform + relativeBoundingRectangle.Position
+            // TopLeft absolute coordinate offset by the top left of relative bounding rect
+            // gives the screen bounding rect
+            ScreenMinimumBoundingRectangle =
+                new RectangleF(
+                    _childPositionTransform.Translation + relativeBoundingRectangle.Position,
+                    relativeBoundingRectangle.Size);
 
             for (var i = 0; i < Children.Count; i++)
                 Children[i].RecalculateRectangles();

--- a/Wobble/Graphics/GraphicsHelper.cs
+++ b/Wobble/Graphics/GraphicsHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.Xna.Framework;
 using MonoGame.Extended;
 
@@ -11,13 +12,15 @@ namespace Wobble.Graphics
         /// </summary>
         /// <param name="scale">The value (percentage) which the object will be aligned to (0=min, 0.5 =mid, 1.0 = max)</param>
         /// <param name="objectSize">The size of the object</param>
-        /// <param name="boundaryX"></param>
-        /// <param name="boundaryY"></param>
+        /// <param name="boundaryLeft"></param>
+        /// <param name="boundaryRight"></param>
         /// <param name="offset"></param>
+        /// <param name="relative"></param>
         /// <returns></returns>
-        public static float Align(float scale, float objectSize, float boundaryX, float boundaryY, float offset = 0)
+        public static float Align(float scale, float objectSize, float boundaryLeft, float boundaryRight, float offset = 0, bool relative = false)
         {
-            return Math.Min(boundaryX, boundaryY) + (Math.Abs(boundaryX - boundaryY) - objectSize) * scale + offset;
+            var res = (boundaryRight - boundaryLeft - objectSize) * scale + offset;
+            return relative ? res : boundaryLeft + res;
         }
 
         /// <summary>
@@ -26,8 +29,9 @@ namespace Wobble.Graphics
         /// <param name="objectAlignment">The alignment of the object.</param>
         /// <param name="objectRect">The size of the object.</param>
         /// <param name="boundary">The Rectangle of the boundary.</param>
+        /// <param name="relative"></param>
         /// <returns></returns>
-        public static RectangleF AlignRect(Alignment objectAlignment, RectangleF objectRect, RectangleF boundary)
+        public static RectangleF AlignRect(Alignment objectAlignment, RectangleF objectRect, RectangleF boundary, bool relative = false)
         {
             float alignX = 0;
             float alignY = 0;
@@ -67,11 +71,42 @@ namespace Wobble.Graphics
             }
 
             //Set X and Y Alignments
-            alignX = Align(alignX, objectRect.Width, boundary.X, boundary.X + boundary.Width, objectRect.X);
-            alignY = Align(alignY, objectRect.Height, boundary.Y, boundary.Y + boundary.Height, objectRect.Y);
+            alignX = Align(alignX, objectRect.Width, boundary.X, boundary.X + boundary.Width, objectRect.X, relative);
+            alignY = Align(alignY, objectRect.Height, boundary.Y, boundary.Y + boundary.Height, objectRect.Y, relative);
 
             return new RectangleF(alignX, alignY, objectRect.Width, objectRect.Height);
         }
+
+        public static RectangleF Offset(RectangleF objectRect, RectangleF offset)
+        {
+            return new RectangleF(objectRect.X + offset.X, objectRect.Y + offset.Y,
+                objectRect.Width, objectRect.Height);
+        }
+
+        public static RectangleF Transform(RectangleF objectRect, Matrix2D matrix, Vector2 scale)
+        {
+            var resultPosition = matrix.Transform(objectRect.Position);
+            var resultSize = new Size2(objectRect.Width * scale.X, objectRect.Height * scale.Y);
+            return new RectangleF(resultPosition, resultSize);
+        }
+
+        public static RectangleF MinimumBoundingRectangle(RectangleF objectRect, float angleRadians, bool relative = false)
+        {
+            var cos = MathF.Cos(angleRadians);
+            var sin = MathF.Sin(angleRadians);
+            var topLeft = Vector2.Zero;
+            var bottomLeft = new Vector2(-sin * objectRect.Height, cos * objectRect.Height);
+            var bottomRight = new Vector2(cos * objectRect.Width - sin * objectRect.Height, sin * objectRect.Width + cos * objectRect.Height);
+            var topRight = new Vector2(cos * objectRect.Width, sin * objectRect.Width);
+            var minX = MathF.Min(MathF.Min(topLeft.X, bottomLeft.X), MathF.Min(bottomRight.X, topRight.X));
+            var minY = MathF.Min(MathF.Min(topLeft.Y, bottomLeft.Y), MathF.Min(bottomRight.Y, topRight.Y));
+            var maxX = MathF.Max(MathF.Max(topLeft.X, bottomLeft.X), MathF.Max(bottomRight.X, topRight.X));
+            var maxY = MathF.Max(MathF.Max(topLeft.Y, bottomLeft.Y), MathF.Max(bottomRight.Y, topRight.Y));
+            var minimumBoundingRectangle = new RectangleF(minX, minY, maxX - minX, maxY - minY);
+            if (!relative)
+                minimumBoundingRectangle.Offset(objectRect.Position);
+            return minimumBoundingRectangle;
+        } 
 
         /// <summary>
         ///     Converts a Vector2 to Point

--- a/Wobble/Graphics/SpriteBatchOptions.cs
+++ b/Wobble/Graphics/SpriteBatchOptions.cs
@@ -16,7 +16,7 @@ namespace Wobble.Graphics
         public BlendState BlendState { get; set; } = BlendState.NonPremultiplied;
         public SamplerState SamplerState { get; set; } = SamplerState.LinearClamp;
         public DepthStencilState DepthStencilState { get; set; }
-        public RasterizerState RasterizerState { get; set; }
+        public RasterizerState RasterizerState { get; set; } = RasterizerState.CullNone;
         /// <summary>
         ///     Custom shader for this sprite.
         /// </summary>

--- a/Wobble/Graphics/Sprites/Sprite.cs
+++ b/Wobble/Graphics/Sprites/Sprite.cs
@@ -25,25 +25,28 @@ namespace Wobble.Graphics.Sprites
 
                 _image = value;
 
-                Origin = new Vector2(Image.Width / 2f, Image.Height / 2f);
+                Origin = new Vector2(Image.Width * Pivot.X, Image.Height * Pivot.Y);
                 RecalculateRectangles();
             }
         }
 
         /// <summary>
-        ///     Angle of the sprite with it's origin in the centre. (TEMPORARILY NOT USED YET)
-        /// </summary>
-        private float _rotation;
-        public float Rotation
-        {
-            get => _rotation;
-            set => _rotation = MathHelper.ToRadians(value);
-        }
-
-        /// <summary>
         ///     The XNA SpriteEffects the sprite will have.
+        ///     When the sprite is negatively scaled on some axis, it will be flipped over that axis too.
         /// </summary>
-        public SpriteEffects SpriteEffect { get; set; } = SpriteEffects.None;
+        public SpriteEffects SpriteEffect
+        {
+            get
+            {
+                var spriteEffects = _spriteEffect;
+                // if (ScreenRectangle.Width < 0)
+                //     spriteEffects ^= SpriteEffects.FlipHorizontally;
+                // if (ScreenRectangle.Height < 0)
+                //     spriteEffects ^= SpriteEffects.FlipVertically;
+                return spriteEffects;
+            }
+            set => _spriteEffect = value;
+        }
 
         /// <summary>
         ///     The origin of this object used for rotation.
@@ -101,6 +104,42 @@ namespace Wobble.Graphics.Sprites
         ///     Dictates if we want to set the alpha of the children as well.
         /// </summary>
         public bool SetChildrenAlpha { get; set; }
+
+        /// <summary>
+        ///     Additional rotation applied to this sprite only, and not to its children
+        /// </summary>
+        public float SpriteRotation
+        {
+            get => _spriteRotation;
+            set
+            {
+                _spriteRotation = value;
+                SpriteOverallRotation = _spriteRotation + (IndependentRotation ? Rotation : AbsoluteRotation);
+            }
+        }
+
+        private bool _independentRotation;
+        private SpriteEffects _spriteEffect = SpriteEffects.None;
+        private float _spriteRotation;
+
+        /// <summary>
+        ///     If true, the rotation of sprite shown on screen will be independent of its parent.
+        /// </summary>
+        public bool IndependentRotation
+        {
+            get => _independentRotation;
+            set
+            {
+                _independentRotation = value;
+                SpriteRotation = SpriteRotation;
+            }
+        }
+
+        /// <summary>
+        ///     Actual rotation of sprite shown on screen.
+        ///     It is decided by <see cref="IndependentRotation"/> and parent's <see cref="Drawable.AbsoluteRotation"/>
+        /// </summary>
+        public float SpriteOverallRotation { get; protected set; }
 
         /// <inheritdoc />
         /// <summary>
@@ -163,7 +202,7 @@ namespace Wobble.Graphics.Sprites
             if (!Visible)
                 return;
 
-            GameBase.Game.SpriteBatch.Draw(Image, RenderRectangle, null, _color, _rotation, Origin, SpriteEffect, 0f);
+            GameBase.Game.SpriteBatch.Draw(Image, RenderRectangle, null, _color, SpriteOverallRotation, Origin, SpriteEffect, 0f);
         }
 
         /// <inheritdoc />
@@ -183,10 +222,35 @@ namespace Wobble.Graphics.Sprites
             if (Image == null)
                 return;
 
+            var pivot = Pivot;
+            var screenRectangleSize = ScreenRectangle.Size;
+
+            // // It seems like it's impossible to render textures with one of the axis flipped,
+            // // so we need manual adjustments: flip the image back so its size is always positive,
+            // // and flip the pivot correspondingly
+            // if (screenRectangleSize.Width < 0)
+            // {
+            //     pivot.X = 1 - pivot.X;
+            //     screenRectangleSize.Width = -screenRectangleSize.Width;
+            // }
+            //
+            // if (screenRectangleSize.Height < 0)
+            // {
+            //     pivot.Y = 1 - pivot.Y;
+            //     screenRectangleSize.Height = -screenRectangleSize.Height;
+            // }
+
+            Origin = new Vector2(pivot.X * Image.Width, pivot.Y * Image.Height);
+
+            // The render rectangle's position will rotate around the screen rectangle's position
+            var rotatedScreenOrigin = (ScreenRectangle.Size * Pivot).Rotate(Parent?.AbsoluteRotation ?? 0);
+
             // Update the render rectangle
-            // Add Width / 2 and Height / 2 to X, Y because that's what Origin is set to (in the Image setter).
-            RenderRectangle = new RectangleF(ScreenRectangle.X + ScreenRectangle.Width / 2f, ScreenRectangle.Y + ScreenRectangle.Height / 2f,
-                ScreenRectangle.Width, ScreenRectangle.Height);
+            RenderRectangle = new RectangleF(
+                ScreenRectangle.Position + rotatedScreenOrigin,
+                screenRectangleSize);
+
+            SpriteRotation = SpriteRotation;
         }
 
         /// <summary>

--- a/Wobble/Graphics/Sprites/Sprite.cs
+++ b/Wobble/Graphics/Sprites/Sprite.cs
@@ -34,19 +34,7 @@ namespace Wobble.Graphics.Sprites
         ///     The XNA SpriteEffects the sprite will have.
         ///     When the sprite is negatively scaled on some axis, it will be flipped over that axis too.
         /// </summary>
-        public SpriteEffects SpriteEffect
-        {
-            get
-            {
-                var spriteEffects = _spriteEffect;
-                // if (ScreenRectangle.Width < 0)
-                //     spriteEffects ^= SpriteEffects.FlipHorizontally;
-                // if (ScreenRectangle.Height < 0)
-                //     spriteEffects ^= SpriteEffects.FlipVertically;
-                return spriteEffects;
-            }
-            set => _spriteEffect = value;
-        }
+        public SpriteEffects SpriteEffect { get; set; } = SpriteEffects.None;
 
         /// <summary>
         ///     The origin of this object used for rotation.
@@ -119,7 +107,6 @@ namespace Wobble.Graphics.Sprites
         }
 
         private bool _independentRotation;
-        private SpriteEffects _spriteEffect = SpriteEffects.None;
         private float _spriteRotation;
 
         /// <summary>
@@ -224,21 +211,6 @@ namespace Wobble.Graphics.Sprites
 
             var pivot = Pivot;
             var screenRectangleSize = ScreenRectangle.Size;
-
-            // // It seems like it's impossible to render textures with one of the axis flipped,
-            // // so we need manual adjustments: flip the image back so its size is always positive,
-            // // and flip the pivot correspondingly
-            // if (screenRectangleSize.Width < 0)
-            // {
-            //     pivot.X = 1 - pivot.X;
-            //     screenRectangleSize.Width = -screenRectangleSize.Width;
-            // }
-            //
-            // if (screenRectangleSize.Height < 0)
-            // {
-            //     pivot.Y = 1 - pivot.Y;
-            //     screenRectangleSize.Height = -screenRectangleSize.Height;
-            // }
 
             Origin = new Vector2(pivot.X * Image.Width, pivot.Y * Image.Height);
 

--- a/Wobble/Graphics/Sprites/SpriteTextBitmap.cs
+++ b/Wobble/Graphics/Sprites/SpriteTextBitmap.cs
@@ -128,8 +128,8 @@ namespace Wobble.Graphics.Sprites
             }
             else
             {
-                GameBase.Game.SpriteBatch.DrawString(Font, DisplayedText, AbsolutePosition, _color, Rotation,
-                    Vector2.Zero, new Vector2((float)FontSize / Font.LineHeight, (float)FontSize / Font.LineHeight),
+                GameBase.Game.SpriteBatch.DrawString(Font, DisplayedText, AbsolutePosition, _color, AbsoluteRotation,
+                    Vector2.Zero, new Vector2((float)FontSize / Font.LineHeight, (float)FontSize / Font.LineHeight) * AbsoluteScale,
                     Effects, 0, null);
             }
         }

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
@@ -310,7 +310,7 @@ namespace Wobble.Graphics.Sprites.Text
                 return;
 
             SetSize();
-            GameBase.Game.SpriteBatch.DrawString(Font.Store, Text, AbsolutePosition, _tint * Alpha);
+            GameBase.Game.SpriteBatch.DrawString(Font.Store, Text, AbsolutePosition, _tint * Alpha, AbsoluteScale);
         }
 
         private void SetSize()

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlusLineRaw.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlusLineRaw.cs
@@ -60,7 +60,7 @@ namespace Wobble.Graphics.Sprites.Text
                 return;
 
             Font.Store.Size = FontSize;
-            GameBase.Game.SpriteBatch.DrawString(Font.Store, Text, AbsolutePosition, _color);
+            GameBase.Game.SpriteBatch.DrawString(Font.Store, Text, AbsolutePosition, _color, AbsoluteScale);
         }
 
         private void RefreshSize()


### PR DESCRIPTION
Resolves #162 

This PR adds scaling and rotation around a pivot for any drawables, not limited to sprites.
Changes & Features:
* We use matrix calculation now, there *might be* performance issues, but its not obvious
* Rotation and scaling applies to their descendents
* Sprites have `IndependentRotation` now, which when set fixes the rotation of the sprite
* Merging this change will require Quaver's menu visualiser bar to have IndependentRotation set, and no other observable change needs to be done at the point
* This will enable the capability of letterboxing and scaling gameplay view down so it can contain more people on the same screen.