### PR TITLE
Update to .net8

### DIFF
--- a/Wobble.Extended/Wobble.Extended.csproj
+++ b/Wobble.Extended/Wobble.Extended.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Wobble.Tests.Hotload/Wobble.Tests.Hotload.csproj
+++ b/Wobble.Tests.Hotload/Wobble.Tests.Hotload.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Wobble.Tests.Unit/Wobble.Tests.Unit.csproj
+++ b/Wobble.Tests.Unit/Wobble.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Wobble.Tests/Wobble.Tests.csproj
+++ b/Wobble.Tests/Wobble.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />

--- a/Wobble/Wobble.csproj
+++ b/Wobble/Wobble.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/Wobble/WobbleGame.cs
+++ b/Wobble/WobbleGame.cs
@@ -21,6 +21,7 @@ using Wobble.Platform;
 using Wobble.Platform.Linux;
 using Wobble.Screens;
 using Wobble.Window;
+using NativeLibrary = Wobble.Platform.Linux.NativeLibrary;
 
 namespace Wobble
 {


### PR DESCRIPTION
`NativeLibrary` is explicitly imported because of a class with the same name being introduced in .net 8