### PR TITLE
Perf memory optimizations

### DIFF
--- a/Wobble.Tests/Screens/Tests/Audio/TestAudioScreen.cs
+++ b/Wobble.Tests/Screens/Tests/Audio/TestAudioScreen.cs
@@ -55,6 +55,7 @@ namespace Wobble.Tests.Screens.Tests.Audio
         {
             Song?.Dispose();
             Train?.Dispose();
+            HitSound?.Dispose();
 
             base.Destroy();
         }

--- a/Wobble.Tests/Screens/Tests/Background/TestBackgroundImageScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/Background/TestBackgroundImageScreenView.cs
@@ -17,7 +17,7 @@ namespace Wobble.Tests.Screens.Tests.Background
         /// <summary>
         /// </summary>
         /// <param name="screen"></param>
-        public TestBackgroundImageScreenView(Screen screen) : base(screen) => Background = new BackgroundImage(WobbleAssets.WhiteBox, 60)
+        public TestBackgroundImageScreenView(Screen screen) : base(screen) => Background = new BackgroundImage(WobbleAssets.Wallpaper, 60)
         {
             Parent = Container
         };

--- a/Wobble.Tests/Screens/Tests/BlurContainer/TestBlurContainerScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/BlurContainer/TestBlurContainerScreenView.cs
@@ -23,6 +23,8 @@ namespace Wobble.Tests.Screens.Tests.BlurContainer
         /// </summary>
         public SpriteText BlurStrengthText { get; }
 
+        private int _lastStrength;
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -57,6 +59,8 @@ namespace Wobble.Tests.Screens.Tests.BlurContainer
                 Alignment = Alignment.TopCenter,
                 Y = 15,
             };
+
+            _lastStrength = (int)Blur.Strength;
         }
 
         /// <inheritdoc />
@@ -85,7 +89,11 @@ namespace Wobble.Tests.Screens.Tests.BlurContainer
             if (KeyboardManager.IsUniqueKeyPress(Keys.Right))
                 Blur.Strength += 1;
 
-            BlurStrengthText.Text = $"Blur Strength: {Blur.Strength}";
+            if ((int)Blur.Strength != _lastStrength)
+            {
+                _lastStrength = (int)Blur.Strength;
+                BlurStrengthText.Text = $"Blur Strength: {Blur.Strength}";
+            }
             Container?.Update(gameTime);
         }
 

--- a/Wobble.Tests/Screens/Tests/BlurredBgImage/TestBlurredBackgroundImageScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/BlurredBgImage/TestBlurredBackgroundImageScreenView.cs
@@ -11,7 +11,7 @@ namespace Wobble.Tests.Screens.Tests.BlurredBgImage
     {
         public TestBlurredBackgroundImageScreenView(Screen screen) : base(screen)
         {
-            var blur = new GaussianBlur(1.1f);
+            using var blur = new GaussianBlur(1.1f);
             var image = blur.PerformGaussianBlur(WobbleAssets.Wallpaper);
 
             var background = new BackgroundImage(image)

--- a/Wobble.Tests/Screens/Tests/ScheduledUpdates/TestScheduledUpdatesScreenView.cs
+++ b/Wobble.Tests/Screens/Tests/ScheduledUpdates/TestScheduledUpdatesScreenView.cs
@@ -17,6 +17,8 @@ namespace Wobble.Tests.Screens.Tests.ScheduledUpdates
     public class TestScheduledUpdatesScreenView: ScreenView
     {
         private SpriteTextPlus Scheduled { get; }
+        private CancellationTokenSource _updateTokenSource;
+        private Task _updateTask;
 
         /// <summary>
         /// </summary>
@@ -27,20 +29,25 @@ namespace Wobble.Tests.Screens.Tests.ScheduledUpdates
             Scheduled = new SpriteTextPlus(FontManager.GetWobbleFont("exo2-semibold"),
                 "", 36)
             {
+                Parent = Container,
                 Alignment = Alignment.TopCenter,
                 Y = 250
             };
 
-            Task.Run(() =>
+            _updateTokenSource = new CancellationTokenSource();
+            var token = _updateTokenSource.Token;
+            _updateTask = Task.Run(async () =>
             {
-                while (!Scheduled.IsDisposed)
+                while (!token.IsCancellationRequested && !Scheduled.IsDisposed)
                 {
                     if (IsScheduled)
                         Scheduled.ScheduleUpdate(() => Scheduled.Text = $"Scheduled - {DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}");
                     else
                         Scheduled.Text = $"Unscheduled - {DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+
+                    await Task.Delay(16, token);
                 }
-            });
+            }, token);
 
             new SpriteText("exo2-semibold", "Press 1 to toggle between scheduled & unscheduled", 32)
             {
@@ -62,10 +69,16 @@ namespace Wobble.Tests.Screens.Tests.ScheduledUpdates
         {
             GameBase.Game.GraphicsDevice.Clear(Color.CornflowerBlue);
             Container?.Draw(gameTime);
-
-            Scheduled.Draw(gameTime);
         }
 
-        public override void Destroy() => Container?.Destroy();
+        public override void Destroy()
+        {
+            _updateTokenSource?.Cancel();
+            _updateTokenSource?.Dispose();
+            _updateTokenSource = null;
+            _updateTask = null;
+
+            Container?.Destroy();
+        }
     }
 }

--- a/Wobble.Tests/WobbleTestsGame.cs
+++ b/Wobble.Tests/WobbleTestsGame.cs
@@ -8,6 +8,7 @@ using Wobble.Graphics.Sprites.Text;
 using Wobble.Graphics.UI.Debugging;
 using Wobble.Input;
 using Wobble.IO;
+using Wobble.Logging;
 using Wobble.Managers;
 using Wobble.Screens;
 using Wobble.Tests.Screens.Selection;
@@ -23,6 +24,10 @@ namespace Wobble.Tests
         private FpsCounter FpsCounter { get; set; }
         
         private SpriteTextPlus WaylandState { get; set; }
+
+        private bool _logGc;
+        private double _gcLogTimer;
+        private readonly int[] _lastGcCounts = new int[3];
 
         public WobbleTestsGame() : base(true)
         {
@@ -131,6 +136,32 @@ namespace Wobble.Tests
                 WaylandVsync = !WaylandVsync;
                 WaylandState.Text = $"Wayland: {WaylandVsync}";
             }
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.F10))
+            {
+                _logGc = !_logGc;
+                _gcLogTimer = 0;
+                Logger.Debug($"GC logging {(_logGc ? "enabled" : "disabled")}.", LogType.Runtime);
+                LogGc("GC toggle");
+            }
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.F9))
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                LogGc("GC forced");
+            }
+
+            if (_logGc)
+            {
+                _gcLogTimer += gameTime.ElapsedGameTime.TotalMilliseconds;
+                if (_gcLogTimer >= 1000)
+                {
+                    _gcLogTimer = 0;
+                    LogGc("GC tick");
+                }
+            }
         }
 
         protected override void Draw(GameTime gameTime)
@@ -141,6 +172,26 @@ namespace Wobble.Tests
             base.Draw(gameTime);
             GlobalUserInterface?.Draw(gameTime);
             GameBase.Game.TryEndBatch();
+        }
+
+        private void LogGc(string tag)
+        {
+            var totalBytes = GC.GetTotalMemory(false);
+            var gen0 = GC.CollectionCount(0);
+            var gen1 = GC.CollectionCount(1);
+            var gen2 = GC.CollectionCount(2);
+
+            var delta0 = gen0 - _lastGcCounts[0];
+            var delta1 = gen1 - _lastGcCounts[1];
+            var delta2 = gen2 - _lastGcCounts[2];
+
+            _lastGcCounts[0] = gen0;
+            _lastGcCounts[1] = gen1;
+            _lastGcCounts[2] = gen2;
+
+            Logger.Debug(
+                $"{tag}: managed={totalBytes / (1024 * 1024)}MB gen0={gen0}(+{delta0}) gen1={gen1}(+{delta1}) gen2={gen2}(+{delta2})",
+                LogType.Runtime);
         }
     }
 }

--- a/Wobble.Tests/WobbleTestsGame.cs
+++ b/Wobble.Tests/WobbleTestsGame.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using Wobble.Graphics;
-using Wobble.Graphics.BitmapFonts;
 using Wobble.Graphics.Sprites;
 using Wobble.Graphics.Sprites.Text;
 using Wobble.Graphics.UI.Debugging;
@@ -24,7 +22,7 @@ namespace Wobble.Tests
 
         private FpsCounter FpsCounter { get; set; }
         
-        private SpriteText WaylandState { get; set; }
+        private SpriteTextPlus WaylandState { get; set; }
 
         public WobbleTestsGame() : base(true)
         {
@@ -72,36 +70,30 @@ namespace Wobble.Tests
 
             Resources.AddStore(new DllResourceStore("Wobble.Tests.Resources.dll"));
 
-            if (!BitmapFontFactory.CustomFonts.ContainsKey("exo2-bold"))
-                BitmapFontFactory.AddFont("exo2-bold", GameBase.Game.Resources.Get("Wobble.Tests.Resources/Fonts/exo2-bold.ttf"));
+            var fonts = new List<string> { "exo2-bold", "exo2-regular", "exo2-semibold", "exo2-medium" };
+            foreach (var fontName in fonts)
+            {
+                FontManager.CacheWobbleFont(fontName, new WobbleFontStore(20, GameBase.Game.Resources.Get($"Wobble.Tests.Resources/Fonts/{fontName}.ttf")));
+            }
 
-            if (!BitmapFontFactory.CustomFonts.ContainsKey("exo2-regular"))
-                BitmapFontFactory.AddFont("exo2-regular", GameBase.Game.Resources.Get("Wobble.Tests.Resources/Fonts/exo2-regular.ttf"));
-
-            if (!BitmapFontFactory.CustomFonts.ContainsKey("exo2-semibold"))
-                BitmapFontFactory.AddFont("exo2-semibold", GameBase.Game.Resources.Get("Wobble.Tests.Resources/Fonts/exo2-semibold.ttf"));
-
-            if (!BitmapFontFactory.CustomFonts.ContainsKey("exo2-medium"))
-                BitmapFontFactory.AddFont("exo2-medium", GameBase.Game.Resources.Get("Wobble.Tests.Resources/Fonts/exo2-medium.ttf"));
-
-            var font = new WobbleFontStore(20, GameBase.Game.Resources.Get("Wobble.Tests.Resources/Fonts/exo2-semibold.ttf"), new Dictionary<string, byte[]>()
+            var japaneseFont = new WobbleFontStore(20, GameBase.Game.Resources.Get("Wobble.Tests.Resources/Fonts/exo2-semibold.ttf"), new Dictionary<string, byte[]>()
                 {
                     {"Emoji", GameBase.Game.Resources.Get("Wobble.Tests.Resources/Fonts/symbola-emoji.ttf")},
                     {"Japanese", GameBase.Game.Resources.Get("Wobble.Tests.Resources/Fonts/droid-sans-japanese.ttf")}
                 });
 
-            FontManager.CacheWobbleFont("exo2-semibold", font);
+            FontManager.CacheWobbleFont("exo2-semibold-japanese", japaneseFont);
 
             IsReadyToUpdate = true;
 
-            FpsCounter = new FpsCounter(FontManager.LoadBitmapFont("Content/gotham"), 18)
+            FpsCounter = new FpsCounter(FontManager.GetWobbleFont("exo2-semibold"), 18)
             {
                 Parent = GlobalUserInterface,
                 Alignment = Alignment.BotRight,
                 Size = new ScalableVector2(70, 30),
             };
 
-            WaylandState = new SpriteText("exo2-semibold", $"Wayland: {WaylandVsync}", 18)
+            WaylandState = new SpriteTextPlus(FontManager.GetWobbleFont("exo2-semibold"), $"Wayland: {WaylandVsync}", 18)
             {
                 Parent = GlobalUserInterface,
                 Alignment = Alignment.BotRight,
@@ -137,7 +129,7 @@ namespace Wobble.Tests
             if (KeyboardManager.IsUniqueKeyPress(Keys.W) && OperatingSystem.IsLinux())
             {
                 WaylandVsync = !WaylandVsync;
-                WaylandState.ScheduleUpdate(() => WaylandState.Text = $"Wayland: {WaylandVsync}");
+                WaylandState.Text = $"Wayland: {WaylandVsync}";
             }
         }
 

--- a/Wobble/Assets/WobbleAssets.cs
+++ b/Wobble/Assets/WobbleAssets.cs
@@ -27,6 +27,10 @@ namespace Wobble.Assets
         /// <summary>
         ///     Disposes of all the assets that Wobble has included
         /// </summary>
-        internal static void Dispose() => WhiteBox.Dispose();
+        internal static void Dispose()
+        {
+            WhiteBox?.Dispose();
+            Wallpaper?.Dispose();
+        }
     }
 }

--- a/Wobble/Audio/AudioManager.cs
+++ b/Wobble/Audio/AudioManager.cs
@@ -64,7 +64,21 @@ namespace Wobble.Audio
         /// <summary>
         ///     Disposes of any resources used by BASS.
         /// </summary>
-        internal static void Dispose() => Bass.Free();
+        internal static void Dispose()
+        {
+            if (Tracks != null)
+            {
+                lock (Tracks)
+                {
+                    for (var i = 0; i < Tracks.Count; i++)
+                        Tracks[i]?.Dispose();
+
+                    Tracks.Clear();
+                }
+            }
+
+            Bass.Free();
+        }
 
         /// <summary>
         ///     Updates the AudioManager and keeps things up-to-date.

--- a/Wobble/Graphics/BitmapFonts/BitmapFontFactory.cs
+++ b/Wobble/Graphics/BitmapFonts/BitmapFontFactory.cs
@@ -106,6 +106,9 @@ namespace Wobble.Graphics.BitmapFonts
             textSize.Width = Math.Max(1, textSize.Width);
             textSize.Height = Math.Max(1, textSize.Height);
 
+            // Add a pad based on font size to avoid descender clipping when rendering into the bitmap.
+            textSize.Height += Math.Max(2f, fontSize * 0.25f);
+
             // Create the actual bitmap using the size of the text.
             using (var bmp = new Bitmap((int)(textSize.Width + 0.5), (int)(textSize.Height + 0.5), PixelFormat.Format32bppArgb))
             using (var g = System.Drawing.Graphics.FromImage(bmp))

--- a/Wobble/Graphics/Drawable.cs
+++ b/Wobble/Graphics/Drawable.cs
@@ -539,6 +539,12 @@ namespace Wobble.Graphics
                 for (var i = 0; i < Children.Count; i++)
                 {
                     var drawable = Children[i];
+                    if (drawable == null)
+                    {
+                        Children.RemoveAt(i);
+                        i--;
+                        continue;
+                    }
                     drawable.Draw(gameTime);
 
                     TotalDrawn++;

--- a/Wobble/Graphics/ImGUI/ImGuiRenderer.cs
+++ b/Wobble/Graphics/ImGUI/ImGuiRenderer.cs
@@ -172,7 +172,13 @@ namespace Wobble.Graphics.ImGUI
         /// <summary>
         ///     Removes a previously created texture pointer, releasing its reference and allowing it to be deallocated
         /// </summary>
-        public void UnbindTexture(IntPtr textureId) => LoadedTextures.Remove(textureId);
+        public void UnbindTexture(IntPtr textureId)
+        {
+            if (LoadedTextures.TryGetValue(textureId, out var texture))
+                texture.Dispose();
+
+            LoadedTextures.Remove(textureId);
+        }
 
         /// <summary>
         ///     Sets up ImGui for a new frame, should be called at frame start
@@ -546,6 +552,10 @@ namespace Wobble.Graphics.ImGUI
             if (DestroyContext)
                 ImGui.DestroyContext(Context);
 
+            foreach (var texture in LoadedTextures.Values)
+                texture.Dispose();
+
+            LoadedTextures.Clear();
             Effect?.Dispose();
             RasterizerState?.Dispose();
             VertexBuffer?.Dispose();

--- a/Wobble/Graphics/Shaders/GaussianBlur.cs
+++ b/Wobble/Graphics/Shaders/GaussianBlur.cs
@@ -81,7 +81,7 @@ namespace Wobble.Graphics.Shaders
     /// offsetsHoriz and offsetsVert fields.
     /// </para>
     /// </summary>
-    public class GaussianBlur
+    public class GaussianBlur : IDisposable
     {
         private Game game => GameBase.Game;
         private Effect effect;
@@ -140,6 +140,15 @@ namespace Wobble.Graphics.Shaders
         {
             effect = new Effect(GameBase.Game.GraphicsDevice, GameBase.Game.Resources.Get("Wobble.Resources/Shaders/fast-gaussian-blur.mgfxo"));
             ComputeKernel(7, strength);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Dispose()
+        {
+            effect?.Dispose();
+            effect = null;
         }
 
         /// <summary>

--- a/Wobble/Graphics/Sprites/BakeableSprite.cs
+++ b/Wobble/Graphics/Sprites/BakeableSprite.cs
@@ -68,5 +68,16 @@ namespace Wobble.Graphics.Sprites
 
             HasBeenBaked = true;
         }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            if (BakedRenderTarget != null && !BakedRenderTarget.IsDisposed)
+                BakedRenderTarget.Dispose();
+
+            base.Destroy();
+        }
     }
 }

--- a/Wobble/Graphics/Sprites/BlurContainer.cs
+++ b/Wobble/Graphics/Sprites/BlurContainer.cs
@@ -76,6 +76,31 @@ namespace Wobble.Graphics.Sprites
 
             base.Draw(gameTime);
         }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            var activeEffect = SpriteBatchOptions?.Shader?.ShaderEffect;
+
+            if (SpriteBatchOptions?.Shader != null)
+            {
+                SpriteBatchOptions.Shader.Dispose();
+                SpriteBatchOptions.Shader = null;
+            }
+
+            if (BlurEffects != null)
+            {
+                foreach (var effect in BlurEffects.Values)
+                {
+                    if (!ReferenceEquals(effect, activeEffect))
+                        effect.Dispose();
+                }
+            }
+
+            base.Destroy();
+        }
     }
 
     /// <summary>

--- a/Wobble/Graphics/Sprites/RenderTargetContainer.cs
+++ b/Wobble/Graphics/Sprites/RenderTargetContainer.cs
@@ -69,5 +69,16 @@ namespace Wobble.Graphics.Sprites
             // Attempt to end the spritebatch
             _ = GameBase.Game.TryEndBatch();
         }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            if (RenderTarget != null && !RenderTarget.IsDisposed)
+                RenderTarget.Dispose();
+
+            base.Destroy();
+        }
     }
 }

--- a/Wobble/Graphics/Sprites/Sprite.cs
+++ b/Wobble/Graphics/Sprites/Sprite.cs
@@ -135,7 +135,7 @@ namespace Wobble.Graphics.Sprites
         public override void Draw(GameTime gameTime)
         {
             // If there is no image set, create a dummy 1px one.
-            if (Image == null)
+            if (Image == null || Image.IsDisposed)
                 Image = WobbleAssets.WhiteBox;
 
             if (SpriteBatchOptions != null)

--- a/Wobble/Graphics/Sprites/SpriteAlphaMaskBlend.cs
+++ b/Wobble/Graphics/Sprites/SpriteAlphaMaskBlend.cs
@@ -17,6 +17,12 @@ namespace Wobble.Graphics.Sprites
 
         public Texture2D PerformBlend(Texture2D srcTexture, Texture2D srcMask)
         {
+            if (RenderTarget != null && !RenderTarget.IsDisposed)
+            {
+                RenderTarget.Dispose();
+                RenderTarget = null;
+            }
+
             RenderTarget = new RenderTarget2D(GameBase.Game.GraphicsDevice, srcTexture.Width, srcTexture.Height, false,
                 GameBase.Game.GraphicsDevice.PresentationParameters.BackBufferFormat, DepthFormat.None);
 

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlusLine.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlusLine.cs
@@ -112,7 +112,10 @@ namespace Wobble.Graphics.Sprites.Text
         private static float GetScale()
         {
             var scale = WindowManager.ScreenScale.X;
-            Debug.Assert(scale > 0, "You're setting up text too early (WindowManager.ScreenScale.X is 0).");
+            
+            // Some stuff (namely DrawableLog and the FPS counter) wants to draw text before anything is initialized.
+            if (scale == 0)
+                scale = 1;
 
             if (GameBase.Game.Graphics.PreferredBackBufferWidth < 1600)
                 return scale * 2;

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlusLineRaw.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlusLineRaw.cs
@@ -1,3 +1,4 @@
+using System;
 using Wobble.Window;
 
 namespace Wobble.Graphics.Sprites.Text
@@ -67,7 +68,9 @@ namespace Wobble.Graphics.Sprites.Text
             Font.FontSize = FontSize;
 
             var (x, y) = Font.Store.MeasureString(Text);
-            Size = new ScalableVector2(x, y);
+            var padding = Math.Max(2f, FontSize * 0.25f);
+            var height = Math.Max(y, Font.Store.LineHeight) + padding;
+            Size = new ScalableVector2(x, height);
         }
     }
 }

--- a/Wobble/Graphics/UI/Debugging/FpsCounter.cs
+++ b/Wobble/Graphics/UI/Debugging/FpsCounter.cs
@@ -1,9 +1,9 @@
 using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGame.Extended.BitmapFonts;
-using Wobble.Graphics.BitmapFonts;
 using Wobble.Graphics.Sprites;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Managers;
 
 namespace Wobble.Graphics.UI.Debugging
 {
@@ -20,9 +20,9 @@ namespace Wobble.Graphics.UI.Debugging
         private int FrameCounter { get; set; }
 
         /// <summary>
-        ///     The SpriteText that displays the FPS value.
+        ///     The SpriteTextPlus that displays the FPS value.
         /// </summary>
-        public SpriteTextBitmap TextFps { get; }
+        public SpriteTextPlus TextFps { get; }
 
         /// <summary>
         ///     The current update rate.
@@ -35,9 +35,9 @@ namespace Wobble.Graphics.UI.Debugging
         private int UpdateCounter { get; set; }
 
         /// <summary>
-        ///     The SpriteText that displays the UPS value.
+        ///     The SpriteTextPlus that displays the UPS value.
         /// </summary>
-        public SpriteTextBitmap TextUps { get; }
+        public SpriteTextPlus TextUps { get; }
 
         /// <summary>
         ///     The amount of time elapsed so we can begin counting each second.
@@ -48,20 +48,18 @@ namespace Wobble.Graphics.UI.Debugging
         /// <summary>
         ///     Ctor
         /// </summary>
-        public FpsCounter(BitmapFont font, int size)
+        public FpsCounter(WobbleFontStore font, int size)
         {
-            TextFps = new SpriteTextBitmap(font, "0 FPS", false)
+            TextFps = new SpriteTextPlus(font, "0 FPS", size)
             {
                 Parent = this,
                 Alignment = Alignment.TopRight,
-                FontSize = size
             };
 
-            TextUps = new SpriteTextBitmap(font, "0 UPS", false)
+            TextUps = new SpriteTextPlus(font, "0 UPS", size)
             {
                 Parent = this,
                 Alignment = Alignment.TopRight,
-                FontSize = size,
                 Y = TextFps.Size.Y.Value
             };
         }

--- a/Wobble/Logging/Logger.cs
+++ b/Wobble/Logging/Logger.cs
@@ -152,7 +152,7 @@ namespace Wobble.Logging
                 catch (Exception e)
                 {
                     // If it fails, we can't really handle the error here. This shouldn't happen though.
-                    Console.WriteLine(e);
+                    // Console.WriteLine(e);
                 }
             }
 

--- a/Wobble/Logging/Logger.cs
+++ b/Wobble/Logging/Logger.cs
@@ -152,7 +152,7 @@ namespace Wobble.Logging
                 catch (Exception e)
                 {
                     // If it fails, we can't really handle the error here. This shouldn't happen though.
-                    // Console.WriteLine(e);
+                    Console.WriteLine(e);
                 }
             }
 

--- a/Wobble/Managers/TextureManager.cs
+++ b/Wobble/Managers/TextureManager.cs
@@ -45,10 +45,29 @@ namespace Wobble.Managers
 
             var tex = AssetLoader.LoadTexture2D(GameBase.Game.Resources.Get(name));
             var textures = AssetLoader.LoadSpritesheetFromTexture(tex, rows, columns);
+            tex.Dispose();
 
             TextureAtlases.Add(name, textures);
 
             return textures;
+        }
+
+        /// <summary>
+        ///     Disposes all cached textures and clears the caches.
+        /// </summary>
+        internal static void Dispose()
+        {
+            foreach (var texture in Textures.Values)
+                texture?.Dispose();
+
+            foreach (var atlas in TextureAtlases.Values)
+            {
+                for (var i = 0; i < atlas.Count; i++)
+                    atlas[i]?.Dispose();
+            }
+
+            Textures.Clear();
+            TextureAtlases.Clear();
         }
     }
 }

--- a/Wobble/Window/WindowManager.cs
+++ b/Wobble/Window/WindowManager.cs
@@ -106,7 +106,11 @@ namespace Wobble.Window
         /// <summary>
         ///     Unhooks all events from the WindowManager.
         /// </summary>
-        public static void UnHookEvents() => ResolutionChanged = null;
+        public static void UnHookEvents()
+        {
+            ResolutionChanged = null;
+            VirtualScreenSizeChanged = null;
+        }
 
         /// <summary>
         ///     Changes the size of the virtual screen to be used.

--- a/Wobble/Wobble.csproj
+++ b/Wobble/Wobble.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>

--- a/Wobble/WobbleGame.cs
+++ b/Wobble/WobbleGame.cs
@@ -17,6 +17,7 @@ using Wobble.Graphics.Sprites;
 using Wobble.Input;
 using Wobble.IO;
 using Wobble.Logging;
+using Wobble.Managers;
 using Wobble.Platform;
 using Wobble.Platform.Linux;
 using Wobble.Screens;
@@ -216,6 +217,9 @@ namespace Wobble
         protected override void UnloadContent()
         {
             WobbleAssets.Dispose();
+            TextureManager.Dispose();
+            Resources?.Dispose();
+            Window.ClientSizeChanged -= WindowManager.OnClientSizeChanged;
             WindowManager.UnHookEvents();
             AudioManager.Dispose();
             DiscordManager.Dispose();


### PR DESCRIPTION
Ton of optimizations found via codex
And fixes of some of the tests
Replacing the usage of Bitmap with SpriteTextPlus
Added GC logger to Wobble.Tests
Fixes for weird text rendering, where it was cutting the font at the bottom
Lowers memory usage

----
Unsure the change it made for scheduling, it did made it better from what I can see, but I need to test with the game itself, to see if everything works as expected. Before that change it made GC be called constantly and it never stopped, which was weird.