### PR TITLE
Make Tint property virtual in Sprite class

### DIFF
--- a/Wobble/Graphics/Sprites/Sprite.cs
+++ b/Wobble/Graphics/Sprites/Sprite.cs
@@ -51,7 +51,7 @@ namespace Wobble.Graphics.Sprites
         /// </summary>
         private Color _tint = Color.White;
         public Color _color = Color.White;
-        public Color Tint
+        public virtual Color Tint
         {
             get => _tint;
             set


### PR DESCRIPTION
The Tint property in the Sprite class is now virtual, allowing derived classes to override its behavior if needed.
Refers to: 
https://github.com/Quaver/Quaver/pull/4568