### PR TITLE
Handle missing audio output devices

### DIFF
--- a/Wobble/Audio/AudioManager.cs
+++ b/Wobble/Audio/AudioManager.cs
@@ -62,7 +62,7 @@ namespace Wobble.Audio
                 if (error == Errors.Device)
                     throw new AudioEngineException("Quaver could not find an audio output device. Please connect or enable an audio output device and restart the game.");
 
-                throw new AudioEngineException($"BASS has failed to initialize (error code: {(int)error}, name: \"{error}\")! Are your platform-specific dlls present?");
+                throw new AudioEngineException("Quaver could not find an audio output device. Please connect or enable an audio output device and restart the game.");
             }
 
             Logger.Debug($"BASS version: {Bass.Version}", LogType.Runtime);

--- a/Wobble/Audio/AudioManager.cs
+++ b/Wobble/Audio/AudioManager.cs
@@ -53,6 +53,10 @@ namespace Wobble.Audio
             if (!Bass.Init(device.Value))
             {
                 var error = Bass.LastError;
+
+                if (error == Errors.Device)
+                    throw new AudioEngineException("Quaver could not find an audio output device. Please connect or enable an audio output device and restart the game.");
+
                 throw new AudioEngineException($"BASS has failed to initialize (error code: {(int)error}, name: \"{error}\")! Are your platform-specific dlls present?");
             }
 
@@ -83,7 +87,11 @@ namespace Wobble.Audio
         /// <summary>
         ///     Updates the AudioManager and keeps things up-to-date.
         /// </summary>
-        internal static void Update(GameTime gameTime) => UpdateTracks(gameTime);
+        internal static void Update(GameTime gameTime)
+        {
+            CheckForLostOutputDevice();
+            UpdateTracks(gameTime);
+        }
 
         /// <summary>
         ///     Returns an audio device by its name
@@ -101,6 +109,109 @@ namespace Wobble.Audio
             }
 
             return null;
+        }
+
+        /// <summary>
+        ///     Throws if the initialized output device is no longer available.
+        /// </summary>
+        private static void CheckForLostOutputDevice()
+        {
+            if (Tracks == null)
+                return;
+
+            if (IsCurrentOutputDeviceAvailable())
+                return;
+
+            if (TrySwitchToAvailableOutputDevice())
+                return;
+
+            throw new AudioEngineException("Quaver lost access to its audio output device and could not find another output device. Please connect or enable an audio output device and restart the game.");
+        }
+
+        /// <summary>
+        ///     Checks if the current output device is still usable.
+        /// </summary>
+        private static bool IsCurrentOutputDeviceAvailable()
+        {
+            try
+            {
+                return IsOutputDeviceAvailable(Bass.CurrentDevice);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///     Attempts to switch BASS and active tracks to another available output device.
+        /// </summary>
+        private static bool TrySwitchToAvailableOutputDevice()
+        {
+            var previousDevice = Bass.CurrentDevice;
+
+            for (var i = 1; i < Bass.DeviceCount; i++)
+            {
+                if (i == previousDevice || !TryInitializeOutputDevice(i))
+                    continue;
+
+                try
+                {
+                    Bass.CurrentDevice = i;
+                    MoveTracksToDevice(i);
+                    Logger.Warning($"Lost audio output device. Switched to: {Bass.GetDeviceInfo(i).Name}", LogType.Runtime);
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, LogType.Runtime);
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Returns if a BASS output device can be used.
+        /// </summary>
+        private static bool IsOutputDeviceAvailable(int device)
+        {
+            if (device < 1 || device >= Bass.DeviceCount)
+                return false;
+
+            var info = Bass.GetDeviceInfo(device);
+            return info.IsEnabled && info.IsInitialized;
+        }
+
+        /// <summary>
+        ///     Initializes an enabled output device if it is not already initialized.
+        /// </summary>
+        private static bool TryInitializeOutputDevice(int device)
+        {
+            if (device < 1 || device >= Bass.DeviceCount)
+                return false;
+
+            var info = Bass.GetDeviceInfo(device);
+
+            if (!info.IsEnabled)
+                return false;
+
+            return info.IsInitialized || Bass.Init(device);
+        }
+
+        /// <summary>
+        ///     Moves active track streams to another output device.
+        /// </summary>
+        private static void MoveTracksToDevice(int device)
+        {
+            lock (Tracks)
+            {
+                foreach (var track in Tracks)
+                {
+                    if (track is AudioTrack audioTrack && !audioTrack.IsDisposed)
+                        Bass.ChannelSetDevice(audioTrack.Stream, device);
+                }
+            }
         }
 
         /// <summary>

--- a/Wobble/Audio/AudioManager.cs
+++ b/Wobble/Audio/AudioManager.cs
@@ -57,11 +57,6 @@ namespace Wobble.Audio
 
             if (!Bass.Init(device.Value))
             {
-                var error = Bass.LastError;
-
-                if (error == Errors.Device)
-                    throw new AudioEngineException("Quaver could not find an audio output device. Please connect or enable an audio output device and restart the game.");
-
                 throw new AudioEngineException("Quaver could not find an audio output device. Please connect or enable an audio output device and restart the game.");
             }
 

--- a/Wobble/Audio/AudioManager.cs
+++ b/Wobble/Audio/AudioManager.cs
@@ -57,6 +57,9 @@ namespace Wobble.Audio
 
             if (!Bass.Init(device.Value))
             {
+                var error = Bass.LastError;
+                Logger.Error($"BASS has failed to initialize (error code: {(int)error}, name: \"{error}\")", LogType.Runtime);
+
                 throw new AudioEngineException("Quaver could not find an audio output device. Please connect or enable an audio output device and restart the game.");
             }
 

--- a/Wobble/Audio/AudioManager.cs
+++ b/Wobble/Audio/AudioManager.cs
@@ -23,6 +23,11 @@ namespace Wobble.Audio
         public static List<IAudioTrack> Tracks { get; private set; }
 
         /// <summary>
+        ///     Emitted when the output device is automatically changed.
+        /// </summary>
+        public static event Action<string> OutputDeviceChanged;
+
+        /// <summary>
         ///     Initializes BASS and throws an exception if it fails.
         /// </summary>
         /// <param name="devicePeriod">Set to override the device period, milliseconds.</param>
@@ -159,7 +164,9 @@ namespace Wobble.Audio
                 {
                     Bass.CurrentDevice = i;
                     MoveTracksToDevice(i);
-                    Logger.Warning($"Lost audio output device. Switched to: {Bass.GetDeviceInfo(i).Name}", LogType.Runtime);
+                    var deviceName = Bass.GetDeviceInfo(i).Name;
+                    Logger.Warning($"Lost audio output device. Switched to: {deviceName}", LogType.Runtime);
+                    OutputDeviceChanged?.Invoke(deviceName);
                     return true;
                 }
                 catch (Exception e)

--- a/Wobble/Platform/Linux/LinuxUtils.cs
+++ b/Wobble/Platform/Linux/LinuxUtils.cs
@@ -147,6 +147,17 @@ namespace Wobble.Platform.Linux
         {
         }
 
+        public override void ShowErrorMessage(string title, string message)
+        {
+            if (TryRunDialog("zenity", "--error", "--title", title, "--text", message))
+                return;
+
+            if (TryRunDialog("kdialog", "--error", message, "--title", title))
+                return;
+
+            TryRunDialog("xmessage", "-center", "-title", title, message);
+        }
+
         private static void TryRun(string fileName, params string[] arguments)
         {
             try
@@ -162,6 +173,24 @@ namespace Wobble.Platform.Linux
             catch (Exception)
             {
                 // No matching XDG tool? Oh well.
+            }
+        }
+
+        private static bool TryRunDialog(string fileName, params string[] arguments)
+        {
+            try
+            {
+                var info = new ProcessStartInfo(fileName);
+
+                foreach (var argument in arguments)
+                    info.ArgumentList.Add(argument);
+
+                Process.Start(info)?.WaitForExit();
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
             }
         }
     }

--- a/Wobble/Platform/OSX/OsxUtils.cs
+++ b/Wobble/Platform/OSX/OsxUtils.cs
@@ -39,5 +39,21 @@ namespace Wobble.Platform.OSX
         public override void DisableWindowsKey()
         {
         }
+
+        public override void ShowErrorMessage(string title, string message)
+        {
+            var info = new ProcessStartInfo("osascript")
+            {
+                ArgumentList =
+                {
+                    "-e",
+                    $"display alert {QuoteAppleScript(title)} message {QuoteAppleScript(message)} as critical"
+                }
+            };
+
+            Process.Start(info)?.WaitForExit();
+        }
+
+        private static string QuoteAppleScript(string value) => "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
     }
 }

--- a/Wobble/Platform/Utils.cs
+++ b/Wobble/Platform/Utils.cs
@@ -56,6 +56,13 @@ namespace Wobble.Platform
             string applicationIconPath);
 
         /// <summary>
+        ///     Shows a native error dialog.
+        /// </summary>
+        /// <param name="title">dialog title</param>
+        /// <param name="message">dialog message</param>
+        public abstract void ShowErrorMessage(string title, string message);
+
+        /// <summary>
         ///     Enables the windows key to be used
         /// </summary>
         public abstract void EnableWindowsKey();

--- a/Wobble/Platform/Windows/WindowsUtils.cs
+++ b/Wobble/Platform/Windows/WindowsUtils.cs
@@ -94,7 +94,13 @@ namespace Wobble.Platform.Windows
 
         public override void DisableWindowsKey() => WindowsKey.DisableWindowsKey();
 
+        public override void ShowErrorMessage(string title, string message)
+            => MessageBox(IntPtr.Zero, message, title, 0x00000010);
+
         [DllImport("shell32.dll")]
         private static extern void SHChangeNotify(uint wEventId, uint uFlags, IntPtr dwItem1, IntPtr dwItem2);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern int MessageBox(IntPtr hWnd, string lpText, string lpCaption, uint uType);
     }
 }


### PR DESCRIPTION
Prevents the game from booting if audio output device is not found.
If audio output device is being disconnected while playing, it will try to find new source, if not will kill the game and display error.

Needs to be tested:
- [x] MacOS
- [x] Windows
- [ ] Linux

Tested on CachyOS, it appears that none of the fallbacks work, but nothing breaks either.