### PR TITLE
Font render testing

### DIFF
--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
@@ -3,9 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Wobble.Graphics.Animations;
-using Wobble.Window;
 
 namespace Wobble.Graphics.Sprites.Text
 {
@@ -323,35 +320,7 @@ namespace Wobble.Graphics.Sprites.Text
 #endif
 
             SetSize();
-            DrawUncachedText();
-        }
-
-        private void DrawUncachedText()
-        {
-            var renderScale = SpriteTextPlusLine.GetRenderScale();
-            var screenScale = WindowManager.ScreenScale;
-
-            if (screenScale.X == 0 || screenScale.Y == 0)
-                screenScale = Vector2.One;
-
-            _ = GameBase.Game.TryEndBatch();
-            GameBase.Game.SpriteBatch.Begin(
-                SpriteSortMode.Deferred,
-                BlendState.NonPremultiplied,
-                SamplerState.LinearClamp,
-                null,
-                RasterizerState.CullNone);
-
-            Font.FontSize = FontSize * renderScale;
-            Font.Store.DrawText(
-                GameBase.Game.SpriteBatch,
-                Text,
-                AbsolutePosition * screenScale,
-                _tint * Alpha,
-                scale: AbsoluteScale * screenScale / renderScale);
-
-            _ = GameBase.Game.TryEndBatch();
-            GameBase.DefaultSpriteBatchInUse = false;
+            Font.Store.DrawText(GameBase.Game.SpriteBatch, Text, AbsolutePosition, _tint * Alpha, scale: AbsoluteScale);
         }
 
         public override void Destroy()

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlus.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Wobble.Graphics.Animations;
+using Wobble.Window;
 
 namespace Wobble.Graphics.Sprites.Text
 {
@@ -321,7 +323,35 @@ namespace Wobble.Graphics.Sprites.Text
 #endif
 
             SetSize();
-            Font.Store.DrawText(GameBase.Game.SpriteBatch, Text, AbsolutePosition, _tint * Alpha, scale: AbsoluteScale);
+            DrawUncachedText();
+        }
+
+        private void DrawUncachedText()
+        {
+            var renderScale = SpriteTextPlusLine.GetRenderScale();
+            var screenScale = WindowManager.ScreenScale;
+
+            if (screenScale.X == 0 || screenScale.Y == 0)
+                screenScale = Vector2.One;
+
+            _ = GameBase.Game.TryEndBatch();
+            GameBase.Game.SpriteBatch.Begin(
+                SpriteSortMode.Deferred,
+                BlendState.NonPremultiplied,
+                SamplerState.LinearClamp,
+                null,
+                RasterizerState.CullNone);
+
+            Font.FontSize = FontSize * renderScale;
+            Font.Store.DrawText(
+                GameBase.Game.SpriteBatch,
+                Text,
+                AbsolutePosition * screenScale,
+                _tint * Alpha,
+                scale: AbsoluteScale * screenScale / renderScale);
+
+            _ = GameBase.Game.TryEndBatch();
+            GameBase.DefaultSpriteBatchInUse = false;
         }
 
         public override void Destroy()

--- a/Wobble/Graphics/Sprites/Text/SpriteTextPlusLine.cs
+++ b/Wobble/Graphics/Sprites/Text/SpriteTextPlusLine.cs
@@ -88,7 +88,7 @@ namespace Wobble.Graphics.Sprites.Text
         /// <param name="size"></param>
         public SpriteTextPlusLine(WobbleFontStore font, string text, float size = 0)
         {
-            _scale = GetScale();
+            _scale = GetRenderScale();
 
             _raw = new SpriteTextPlusLineRaw(font, text, size * _scale)
             {
@@ -109,18 +109,15 @@ namespace Wobble.Graphics.Sprites.Text
         ///     Get the current WindowManager scale and check that it's valid.
         /// </summary>
         /// <returns></returns>
-        private static float GetScale()
+        internal static float GetRenderScale()
         {
-            var scale = WindowManager.ScreenScale.X;
+            var scale = Math.Max(WindowManager.ScreenScale.X, WindowManager.ScreenScale.Y);
             
             // Some stuff (namely DrawableLog and the FPS counter) wants to draw text before anything is initialized.
             if (scale == 0)
                 scale = 1;
 
-            if (GameBase.Game.Graphics.PreferredBackBufferWidth < 1600)
-                return scale * 2;
-
-            return scale;
+            return Math.Max(1, scale);
         }
 
         /// <summary>
@@ -144,7 +141,7 @@ namespace Wobble.Graphics.Sprites.Text
         /// <param name="gameTime"></param>
         public override void Update(GameTime gameTime)
         {
-            Scale = GetScale();
+            Scale = GetRenderScale();
 
             if (_dirty)
             {

--- a/Wobble/Graphics/Sprites/Text/WobbleFontStore.cs
+++ b/Wobble/Graphics/Sprites/Text/WobbleFontStore.cs
@@ -10,6 +10,14 @@ namespace Wobble.Graphics.Sprites.Text
         private float _fontSize;
         private readonly FontSystem _fontSystem;
 
+        static WobbleFontStore()
+        {
+            FontSystemDefaults.FontResolutionFactor = 2;
+            FontSystemDefaults.StbTrueTypeUseOldRasterizer = false;
+            FontSystemDefaults.KernelWidth = 2;
+            FontSystemDefaults.KernelHeight = 2;
+        }
+
         /// <summary>
         ///     All of the contained fonts at different sizes
         /// </summary>

--- a/Wobble/Graphics/Sprites/Text/WobbleFontStore.cs
+++ b/Wobble/Graphics/Sprites/Text/WobbleFontStore.cs
@@ -12,10 +12,11 @@ namespace Wobble.Graphics.Sprites.Text
 
         static WobbleFontStore()
         {
-            FontSystemDefaults.FontResolutionFactor = 2;
+            FontSystemDefaults.FontResolutionFactor = 1f;
             FontSystemDefaults.StbTrueTypeUseOldRasterizer = false;
-            FontSystemDefaults.KernelWidth = 2;
-            FontSystemDefaults.KernelHeight = 2;
+            FontSystemDefaults.KernelWidth = 0;
+            FontSystemDefaults.KernelHeight = 0;
+            FontSystemDefaults.GlyphRenderResult = GlyphRenderResult.NonPremultiplied;
         }
 
         /// <summary>

--- a/Wobble/Wobble.csproj
+++ b/Wobble/Wobble.csproj
@@ -8,7 +8,7 @@
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FontStashSharp.MonoGame" Version="1.3.7" />
+    <PackageReference Include="FontStashSharp.MonoGame" Version="1.5.4" />
     <PackageReference Include="ImGui.NET" Version="1.91.0.1" />
     <PackageReference Include="IniFileParserStandard" Version="1.0.1" />
     <PackageReference Include="ManagedBass" Version="3.1.1" />


### PR DESCRIPTION
Updating the lib also gives us some more optimizations according to their release notes.
We also change GlyphRenderResult to be NonPremultiplied to make the text better to read on smaller and larger resolutions.