### PR TITLE
Output device bugs after reconnection

### DIFF
--- a/Wobble/Audio/AudioManager.cs
+++ b/Wobble/Audio/AudioManager.cs
@@ -107,9 +107,25 @@ namespace Wobble.Audio
                 }
             }
 
-            Bass.Free();
+            FreeAllInitializedDevices();
             OutputLatency = 0;
             MinimumBufferLength = 0;
+        }
+
+        /// <summary>
+        ///     Frees every initialized BASS device, not just the current one, so a leftover device from the
+        ///     lost-device fallback can't block re-initializing it later.
+        /// </summary>
+        private static void FreeAllInitializedDevices()
+        {
+            for (var i = 0; i < Bass.DeviceCount; i++)
+            {
+                if (!Bass.GetDeviceInfo(i).IsInitialized)
+                    continue;
+
+                Bass.CurrentDevice = i;
+                Bass.Free();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Made by TDMG
Fixes audio breaking / game bugging when you switch output devices after your headset (or other device) reconnects. When the game loses your audio device it automaticly switches to a backup one, but never properly lets go of the old device. So if you switch back later the game tries to grab a device it's still secretly holding and that fails breaking audio until you restart. Now it lets go of every device it's holding before switching instead of the current one so this can't happen anymore.