### PR TITLE
Enhance debugger menu

### DIFF
--- a/Wobble/Graphics/HorizontalClippingContainer.cs
+++ b/Wobble/Graphics/HorizontalClippingContainer.cs
@@ -93,7 +93,7 @@ namespace Wobble.Graphics
             var options = GameBase.DefaultSpriteBatchOptions;
             var transform = options.DoNotScale ? (Matrix?)null : WindowManager.Scale;
 
-            GameBase.Game.SpriteBatch.Begin(options.SortMode, options.BlendState, options.SamplerState,
+            GameBase.Game.BeginBatch(options.SortMode, options.BlendState, options.SamplerState,
                 options.DepthStencilState, ScissorRasterizer, options.Shader?.ShaderEffect, transform);
             GameBase.DefaultSpriteBatchInUse = false;
         }

--- a/Wobble/Graphics/Shaders/GaussianBlur.cs
+++ b/Wobble/Graphics/Shaders/GaussianBlur.cs
@@ -262,9 +262,9 @@ namespace Wobble.Graphics.Shaders
             effect.Parameters["offsets"].SetValue(offsetsHoriz);
 
             GameBase.Game.TryEndBatch();
-            GameBase.Game.SpriteBatch.Begin(0, BlendState.Opaque, null, null, null, effect);
+            GameBase.Game.BeginBatch(0, BlendState.Opaque, null, null, null, effect);
             GameBase.Game.SpriteBatch.Draw(srcTexture, destRect1, Color.White);
-            GameBase.Game.SpriteBatch.End();
+            GameBase.Game.EndBatch();
 
             // Perform vertical Gaussian blur.
 
@@ -274,9 +274,9 @@ namespace Wobble.Graphics.Shaders
             effect.Parameters["colorMapTexture"].SetValue(outputTexture);
             effect.Parameters["offsets"].SetValue(offsetsVert);
 
-            GameBase.Game.SpriteBatch.Begin(0, BlendState.Opaque, null, null, null, effect);
+            GameBase.Game.BeginBatch(0, BlendState.Opaque, null, null, null, effect);
             GameBase.Game.SpriteBatch.Draw(outputTexture, destRect2, Color.White);
-            GameBase.Game.SpriteBatch.End();
+            GameBase.Game.EndBatch();
 
             // Return the Gaussian blurred texture.
 

--- a/Wobble/Graphics/SpriteBatchOptions.cs
+++ b/Wobble/Graphics/SpriteBatchOptions.cs
@@ -47,7 +47,7 @@ namespace Wobble.Graphics
                 matrix = null;
 
             _ = GameBase.Game.TryEndBatch();
-            GameBase.Game.SpriteBatch.Begin(SortMode, BlendState, SamplerState, DepthStencilState, RasterizerState, Shader?.ShaderEffect, matrix);
+            GameBase.Game.BeginBatch(SortMode, BlendState, SamplerState, DepthStencilState, RasterizerState, Shader?.ShaderEffect, matrix);
         }
     }
 }

--- a/Wobble/Graphics/Sprites/AnimatableSprite.cs
+++ b/Wobble/Graphics/Sprites/AnimatableSprite.cs
@@ -183,6 +183,12 @@ namespace Wobble.Graphics.Sprites
         public void StopLoop() => IsLooping = false;
 
         /// <summary>
+        ///    Replaces all the frames with full-texture regions.
+        /// </summary>
+        /// <param name="newFrames"></param>
+        public void ReplaceFrames(List<Texture2D> newFrames) => ReplaceFrames(newFrames.Select(TextureRegion.From).ToList());
+
+        /// <summary>
         ///    Replaces all the frames with some new ones.
         /// </summary>
         /// <param name="newFrames"></param>

--- a/Wobble/Graphics/Sprites/AnimatableSprite.cs
+++ b/Wobble/Graphics/Sprites/AnimatableSprite.cs
@@ -82,7 +82,7 @@ namespace Wobble.Graphics.Sprites
         public AnimatableSprite(List<Texture2D> frames) : this(frames.Select(f =>
             new TextureRegion(f, f.Bounds)).ToList())
         {
-            
+
         }
 
         /// <inheritdoc />
@@ -181,12 +181,6 @@ namespace Wobble.Graphics.Sprites
         ///     To stop the animation frame loop.
         /// </summary>
         public void StopLoop() => IsLooping = false;
-
-        /// <summary>
-        ///    Replaces all the frames with full-texture regions.
-        /// </summary>
-        /// <param name="newFrames"></param>
-        public void ReplaceFrames(List<Texture2D> newFrames) => ReplaceFrames(newFrames.Select(TextureRegion.From).ToList());
 
         /// <summary>
         ///    Replaces all the frames with some new ones.

--- a/Wobble/Graphics/Sprites/SpriteAlphaMaskBlend.cs
+++ b/Wobble/Graphics/Sprites/SpriteAlphaMaskBlend.cs
@@ -37,10 +37,10 @@ namespace Wobble.Graphics.Sprites
             // Attempt to end the spritebatch
             _ = GameBase.Game.TryEndBatch();
 
-            GameBase.Game.SpriteBatch.Begin(blendState: blend);
+            GameBase.Game.BeginBatch(blendState: blend);
             GameBase.Game.SpriteBatch.Draw(srcMask, srcTexture.Bounds, Color.White);
             GameBase.Game.SpriteBatch.Draw(srcTexture, srcTexture.Bounds, Color.White);
-            GameBase.Game.SpriteBatch.End();
+            GameBase.Game.EndBatch();
 
             GameBase.Game.GraphicsDevice.SetRenderTarget(null);
             GameBase.Game.GraphicsDevice.Clear(Color.Black);

--- a/Wobble/Graphics/UI/Debugging/DebugOverlay.cs
+++ b/Wobble/Graphics/UI/Debugging/DebugOverlay.cs
@@ -59,7 +59,7 @@ namespace Wobble.Graphics.UI.Debugging
             ImGui.GetIO().MouseDrawCursor = true;
 
             ImGui.SetNextWindowPos(new Vector2(12, 12), ImGuiCond.FirstUseEver);
-            ImGui.SetNextWindowSize(new Vector2(640, 720), ImGuiCond.FirstUseEver);
+            ImGui.SetNextWindowSize(new Vector2(660, 720), ImGuiCond.FirstUseEver);
             ImGui.SetNextWindowSizeConstraints(new Vector2(360, 240), new Vector2(float.MaxValue, float.MaxValue));
 
             var open = Visible;
@@ -67,6 +67,8 @@ namespace Wobble.Graphics.UI.Debugging
                 ImGuiWindowFlags.HorizontalScrollbar))
             {
                 RenderTiming();
+                ImGui.Separator();
+                RenderGraphicsStats();
                 ImGui.Separator();
                 RenderScene();
                 ImGui.Separator();
@@ -108,7 +110,7 @@ namespace Wobble.Graphics.UI.Debugging
             ImGui.Text($"FPS / UPS: {PerformanceStats.FrameRate} / {PerformanceStats.UpdateRate}");
             ImGui.Text($"Frame: {PerformanceStats.FrameTimeMs:0.00} ms avg {PerformanceStats.AverageFrameTimeMs:0.00} ms");
             ImGui.Text($"Update: {PerformanceStats.UpdateTimeMs:0.00} ms avg {PerformanceStats.AverageUpdateTimeMs:0.00} ms");
-            ImGui.Text($"Draw: {PerformanceStats.DrawTimeMs:0.00} ms avg {PerformanceStats.AverageDrawTimeMs:0.00} ms");
+            ImGui.Text($"Game draw: {PerformanceStats.GameDrawTimeMs:0.00} ms avg {PerformanceStats.AverageGameDrawTimeMs:0.00} ms");
 
             if (ImGui.TreeNode("Phase timings"))
             {
@@ -119,16 +121,50 @@ namespace Wobble.Graphics.UI.Debugging
                 ImGui.Text($"Render targets: {PerformanceStats.ScheduledRenderTargetDrawTimeMs:0.00} ms");
                 ImGui.Text($"Screen draw: {PerformanceStats.ScreenDrawTimeMs:0.00} ms");
                 ImGui.Text($"Global UI draw: {PerformanceStats.GlobalUiDrawTimeMs:0.00} ms");
-                ImGui.Text($"Overlay draw: {PerformanceStats.OverlayDrawTimeMs:0.00} ms");
+                ImGui.Text($"F3 overlay: {PerformanceStats.OverlayDrawTimeMs:0.00} ms");
+                ImGui.Text($"Total draw including F3: {PerformanceStats.DrawTimeMs:0.00} ms");
                 ImGui.TreePop();
             }
         }
 
         private void RenderScene()
         {
+            ImGui.Text("Scene");
             ImGui.Text($"Screen: {PerformanceStats.CurrentScreenName}");
             ImGui.Text($"Drawables drawn: {PerformanceStats.DrawnDrawableCount}");
             ImGui.Text($"Scheduled render targets: {PerformanceStats.ScheduledRenderTargetDrawCount}");
+        }
+
+        private void RenderGraphicsStats()
+        {
+            ImGui.Text("Rendering per frame");
+            ImGui.TextColored(new Vector4(0.55f, 0.65f, 0.75f, 1), "Game rendering only; F3 overlay excluded");
+
+            if (!ImGui.BeginTable("GraphicsMetrics", 2, ImGuiTableFlags.RowBg | ImGuiTableFlags.BordersInnerV))
+                return;
+
+            RenderGraphicsMetric("Draw calls", PerformanceStats.GraphicsDrawCallCount.ToString());
+            RenderGraphicsMetric("Sprites submitted", PerformanceStats.GraphicsSpriteCount.ToString());
+            RenderGraphicsMetric("Sprites / draw call", PerformanceStats.GraphicsSpritesPerDrawCall.ToString("0.0"));
+            RenderGraphicsMetric("Primitives", PerformanceStats.GraphicsPrimitiveCount.ToString());
+            RenderGraphicsMetric("Texture changes", PerformanceStats.GraphicsTextureChangeCount.ToString());
+            RenderGraphicsMetric("Render-target changes", PerformanceStats.GraphicsRenderTargetChangeCount.ToString());
+            RenderGraphicsMetric("Clears", PerformanceStats.GraphicsClearCount.ToString());
+            RenderGraphicsMetric("Pixel-shader changes", PerformanceStats.GraphicsPixelShaderChangeCount.ToString());
+            RenderGraphicsMetric("Vertex-shader changes", PerformanceStats.GraphicsVertexShaderChangeCount.ToString());
+            RenderGraphicsMetric("SpriteBatch begins / ends",
+                $"{PerformanceStats.SpriteBatchBeginCount} / {PerformanceStats.SpriteBatchEndCount}");
+
+            ImGui.EndTable();
+        }
+
+        private static void RenderGraphicsMetric(string label, string value)
+        {
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.TextUnformatted(label);
+            ImGui.TableNextColumn();
+            ImGui.TextUnformatted(value);
         }
 
         private void RenderTextStats()

--- a/Wobble/Graphics/UI/Debugging/PerformanceStats.cs
+++ b/Wobble/Graphics/UI/Debugging/PerformanceStats.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Wobble.Window;
 
 namespace Wobble.Graphics.UI.Debugging
@@ -9,6 +10,7 @@ namespace Wobble.Graphics.UI.Debugging
         public static double FrameTimeMs { get; private set; }
         public static double UpdateTimeMs { get; private set; }
         public static double DrawTimeMs { get; private set; }
+        public static double GameDrawTimeMs { get; private set; }
         public static double InputUpdateTimeMs { get; private set; }
         public static double ScreenUpdateTimeMs { get; private set; }
         public static double GlobalUiUpdateTimeMs { get; private set; }
@@ -21,6 +23,7 @@ namespace Wobble.Graphics.UI.Debugging
         public static double AverageFrameTimeMs { get; private set; }
         public static double AverageUpdateTimeMs { get; private set; }
         public static double AverageDrawTimeMs { get; private set; }
+        public static double AverageGameDrawTimeMs { get; private set; }
 
         public static int FrameRate { get; private set; }
         public static int UpdateRate { get; private set; }
@@ -45,6 +48,21 @@ namespace Wobble.Graphics.UI.Debugging
         public static int ImGuiVertexCount { get; private set; }
         public static int ImGuiIndexCount { get; private set; }
 
+        public static long GraphicsDrawCallCount { get; private set; }
+        public static long GraphicsSpriteCount { get; private set; }
+        public static long GraphicsPrimitiveCount { get; private set; }
+        public static long GraphicsTextureChangeCount { get; private set; }
+        public static long GraphicsRenderTargetChangeCount { get; private set; }
+        public static long GraphicsClearCount { get; private set; }
+        public static long GraphicsPixelShaderChangeCount { get; private set; }
+        public static long GraphicsVertexShaderChangeCount { get; private set; }
+        public static int SpriteBatchBeginCount { get; private set; }
+        public static int SpriteBatchEndCount { get; private set; }
+
+        public static double GraphicsSpritesPerDrawCall => GraphicsDrawCallCount == 0
+            ? 0
+            : (double)GraphicsSpriteCount / GraphicsDrawCallCount;
+
         private static double elapsedSampleMs;
         private static int frameCounter;
         private static int updateCounter;
@@ -58,6 +76,10 @@ namespace Wobble.Graphics.UI.Debugging
         private static int lastGen0Collections;
         private static int lastGen1Collections;
         private static int lastGen2Collections;
+
+        private static GraphicsMetrics graphicsMetricsAtDrawStart;
+        private static int spriteBatchBeginsThisFrame;
+        private static int spriteBatchEndsThisFrame;
 
         public static void BeginUpdate(GameTime gameTime)
         {
@@ -105,21 +127,44 @@ namespace Wobble.Graphics.UI.Debugging
             AverageUpdateTimeMs = Smooth(AverageUpdateTimeMs, updateMs);
         }
 
-        public static void BeginDraw(int scheduledRenderTargetDrawCount, string currentScreenName)
+        public static void BeginDraw(int scheduledRenderTargetDrawCount, string currentScreenName, GraphicsMetrics graphicsMetrics)
         {
             ScheduledRenderTargetDrawCount = scheduledRenderTargetDrawCount;
             CurrentScreenName = currentScreenName ?? "None";
+            graphicsMetricsAtDrawStart = graphicsMetrics;
+            spriteBatchBeginsThisFrame = 0;
+            spriteBatchEndsThisFrame = 0;
+        }
+
+        public static void RecordSpriteBatchBegin() => spriteBatchBeginsThisFrame++;
+
+        public static void RecordSpriteBatchEnd() => spriteBatchEndsThisFrame++;
+
+        public static void RecordGraphicsMetrics(GraphicsMetrics graphicsMetrics)
+        {
+            GraphicsDrawCallCount = graphicsMetrics.DrawCount - graphicsMetricsAtDrawStart.DrawCount;
+            GraphicsSpriteCount = graphicsMetrics.SpriteCount - graphicsMetricsAtDrawStart.SpriteCount;
+            GraphicsPrimitiveCount = graphicsMetrics.PrimitiveCount - graphicsMetricsAtDrawStart.PrimitiveCount;
+            GraphicsTextureChangeCount = graphicsMetrics.TextureCount - graphicsMetricsAtDrawStart.TextureCount;
+            GraphicsRenderTargetChangeCount = graphicsMetrics.TargetCount - graphicsMetricsAtDrawStart.TargetCount;
+            GraphicsClearCount = graphicsMetrics.ClearCount - graphicsMetricsAtDrawStart.ClearCount;
+            GraphicsPixelShaderChangeCount = graphicsMetrics.PixelShaderCount - graphicsMetricsAtDrawStart.PixelShaderCount;
+            GraphicsVertexShaderChangeCount = graphicsMetrics.VertexShaderCount - graphicsMetricsAtDrawStart.VertexShaderCount;
+            SpriteBatchBeginCount = spriteBatchBeginsThisFrame;
+            SpriteBatchEndCount = spriteBatchEndsThisFrame;
         }
 
         public static void RecordDrawTimings(double scheduledRenderTargetDrawMs, double screenDrawMs, double globalUiDrawMs,
-            double overlayDrawMs, double drawMs, int drawnDrawableCount)
+            double overlayDrawMs, double gameDrawMs, double drawMs, int drawnDrawableCount)
         {
             ScheduledRenderTargetDrawTimeMs = scheduledRenderTargetDrawMs;
             ScreenDrawTimeMs = screenDrawMs;
             GlobalUiDrawTimeMs = globalUiDrawMs;
             OverlayDrawTimeMs = overlayDrawMs;
+            GameDrawTimeMs = gameDrawMs;
             DrawTimeMs = drawMs;
             DrawnDrawableCount = drawnDrawableCount;
+            AverageGameDrawTimeMs = Smooth(AverageGameDrawTimeMs, gameDrawMs);
             AverageDrawTimeMs = Smooth(AverageDrawTimeMs, drawMs);
             frameCounter++;
         }

--- a/Wobble/WobbleGame.cs
+++ b/Wobble/WobbleGame.cs
@@ -127,6 +127,8 @@ namespace Wobble
 
         private double DebugGlobalUiDrawMs { get; set; }
 
+        private double DebugGameDrawMs { get; set; }
+
         private int DebugDrawnDrawableCount { get; set; }
 #endif
 
@@ -218,6 +220,32 @@ namespace Wobble
         }
 
         /// <summary>
+        ///     Begins the shared sprite batch and records the transition for the performance debugger.
+        /// </summary>
+        public void BeginBatch(SpriteSortMode sortMode = SpriteSortMode.Deferred, BlendState blendState = null,
+            SamplerState samplerState = null, DepthStencilState depthStencilState = null,
+            RasterizerState rasterizerState = null, Effect effect = null, Matrix? transformMatrix = null)
+        {
+            SpriteBatch.Begin(sortMode, blendState, samplerState, depthStencilState, rasterizerState, effect, transformMatrix);
+
+#if DEBUG
+            PerformanceStats.RecordSpriteBatchBegin();
+#endif
+        }
+
+        /// <summary>
+        ///     Ends the shared sprite batch and records the transition for the performance debugger.
+        /// </summary>
+        public void EndBatch()
+        {
+            SpriteBatch.End();
+
+#if DEBUG
+            PerformanceStats.RecordSpriteBatchEnd();
+#endif
+        }
+
+        /// <summary>
         ///     Attempts to initialize a new sprite, if <see cref="SpriteBatch.End"/> had been called.
         /// </summary>
         /// <returns>Whether <see cref="SpriteBatch.Begin"/> had been called.</returns>
@@ -226,7 +254,7 @@ namespace Wobble
             var ret = _beginCalled(SpriteBatch);
 
             if (!ret)
-                SpriteBatch.Begin();
+                BeginBatch();
 
             return ret;
         }
@@ -241,7 +269,7 @@ namespace Wobble
 
             if (ret)
             {
-                SpriteBatch.End();
+                EndBatch();
                 GameBase.DefaultSpriteBatchInUse = false;
             }
 
@@ -400,7 +428,8 @@ namespace Wobble
             var scheduledRenderTargetDrawCount = ScheduledRenderTargetDrawsToRun.Count;
 
 #if DEBUG
-            PerformanceStats.BeginDraw(scheduledRenderTargetDrawCount, ScreenManager.CurrentScreenName);
+            PerformanceStats.BeginDraw(scheduledRenderTargetDrawCount, ScreenManager.CurrentScreenName,
+                GraphicsDevice.Metrics);
 #endif
 
             for (var i = scheduledRenderTargetDrawCount - 1; i >= 0; i--)
@@ -436,6 +465,11 @@ namespace Wobble
 #endif
 
             TryEndBatch();
+
+#if DEBUG
+            DebugGameDrawMs = ElapsedMilliseconds(DebugDrawStartedTimestamp);
+            PerformanceStats.RecordGraphicsMetrics(GraphicsDevice.Metrics);
+#endif
         }
 
 #if DEBUG
@@ -443,12 +477,18 @@ namespace Wobble
         {
             if (IsReadyToUpdate)
             {
-                var overlayStartedTimestamp = Stopwatch.GetTimestamp();
-                DebugOverlay?.Draw(DebugDrawGameTime);
-                var overlayDrawMs = ElapsedMilliseconds(overlayStartedTimestamp);
+                var overlayDrawMs = 0d;
+
+                if (DebugOverlay?.Visible == true)
+                {
+                    var overlayStartedTimestamp = Stopwatch.GetTimestamp();
+                    DebugOverlay.Draw(DebugDrawGameTime);
+                    TryEndBatch();
+                    overlayDrawMs = ElapsedMilliseconds(overlayStartedTimestamp);
+                }
 
                 PerformanceStats.RecordDrawTimings(DebugScheduledRenderTargetDrawMs, DebugScreenDrawMs, DebugGlobalUiDrawMs, overlayDrawMs,
-                    ElapsedMilliseconds(DebugDrawStartedTimestamp), DebugDrawnDrawableCount);
+                    DebugGameDrawMs, ElapsedMilliseconds(DebugDrawStartedTimestamp), DebugDrawnDrawableCount);
             }
 
             if (SpriteBatch != null)


### PR DESCRIPTION
Adds GraphicMetrics to have better clues on how many sprites / textures are rendered in real time while looking at the debugger menu