### PR TITLE
Fix texture creation freezing the game when done off the main thread (consistent when going back from download)

### DIFF
--- a/Wobble/Graphics/Shaders/RoundedRectTextureCache.cs
+++ b/Wobble/Graphics/Shaders/RoundedRectTextureCache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -33,8 +34,31 @@ namespace Wobble.Graphics.Shaders
         public static Texture2D Get(float width, float height, RoundedRectCornerRadii radii,
             bool antiAliased = true)
         {
-            lock (SyncRoot)
-                return GetCached(width, height, radii, antiAliased);
+            if (Thread.CurrentThread.ManagedThreadId == GameBase.Game.MainThreadId)
+            {
+                lock (SyncRoot)
+                    return GetCached(width, height, radii, antiAliased);
+            }
+            
+            Texture2D result = null;
+
+            using var completed = new ManualResetEventSlim(false);
+
+            GameBase.Game.ScheduleRenderTargetDraw(() =>
+            {
+                try
+                {
+                    lock (SyncRoot)
+                        result = GetCached(width, height, radii, antiAliased);
+                }
+                finally
+                {
+                    completed.Set();
+                }
+            });
+
+            completed.Wait();
+            return result;
         }
 
         private static Texture2D GetCached(float width, float height, RoundedRectCornerRadii radii,


### PR DESCRIPTION
This PR fixes it so going from the download screen back to the main menu doesn't freeze the game on a black screen anymore. This happened because creating button textures was being done from a background thread while the main thread was still drawing which could hang. Likely the reason that it consistently hung when coming back from download was because it draws more then other screens. Fixed by making that texture creation always happen on the main thread instead.